### PR TITLE
Missing escape chars in healthcheck variables

### DIFF
--- a/docker-compose/withPostgresAndWorker/docker-compose.yml
+++ b/docker-compose/withPostgresAndWorker/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       - db_storage:/var/lib/postgresql/data
       - ./init-data.sh:/docker-entrypoint-initdb.d/init-data.sh
     healthcheck:
-      test: ['CMD-SHELL', 'pg_isready -h localhost -U ${POSTGRES_USER} -d ${POSTGRES_DB}']
+      test: ['CMD-SHELL', 'pg_isready -h localhost -U $${POSTGRES_USER} -d $${POSTGRES_DB}']
       interval: 5s
       timeout: 5s
       retries: 10


### PR DESCRIPTION
Added missing $ to escape the variables so it can be expanded inside the container. Otherwise the healtcheck outputs and error and docker considers the variables as blank.

```
$ sudo docker-compose up
WARNING: The POSTGRES_USER variable is not set. Defaulting to a blank string. WARNING: The POSTGRES_DB variable is not set. Defaulting to a blank string.
```

Logs:
`postgres_1    | 2024-11-30 01:36:40.966 UTC [917] FATAL:  role "-d" does not exist`