### PR TITLE
Fix docker compose subfolder example

### DIFF
--- a/docker-compose/subfolderWithSSL/.env
+++ b/docker-compose/subfolderWithSSL/.env
@@ -9,7 +9,7 @@ SUBFOLDER=app1
 N8N_PATH=/app1/
 
 # DOMAIN_NAME and SUBDOMAIN combined decide where n8n will be reachable from
-# above example would result in: https://example.com/n8n/
+# above example would result in: https://example.com/app1/
 
 # Optional timezone to set which gets used by Cron-Node by default
 # If not set New York time will be used


### PR DESCRIPTION
Fixing the docker compose subfolder example to display the correct final url