### PR TITLE
docker-compose.yml file update

### DIFF
--- a/docker-compose/withPostgres/docker-compose.yml
+++ b/docker-compose/withPostgres/docker-compose.yml
@@ -9,11 +9,11 @@ services:
     image: postgres:16
     restart: always
     environment:
-      - POSTGRES_USER
-      - POSTGRES_PASSWORD
-      - POSTGRES_DB
-      - POSTGRES_NON_ROOT_USER
-      - POSTGRES_NON_ROOT_PASSWORD
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=${POSTGRES_DB}
+      - POSTGRES_NON_ROOT_USER=${POSTGRES_NON_ROOT_USER}
+      - POSTGRES_NON_ROOT_PASSWORD=${POSTGRES_NON_ROOT_PASSWORD}
     volumes:
       - db_storage:/var/lib/postgresql/data
       - ./init-data.sh:/docker-entrypoint-initdb.d/init-data.sh


### PR DESCRIPTION
Environment variables in docker-compose.yml file set for postgres service using values from .env file. if we run without setting environment variable for postgres service, db container doesn't run and n8n doesn't work properly locally.