### PR TITLE
Fix n8n crash loop due to missing pgcrypto extension in Postgres

### DIFF
--- a/kubernetes/postgres-configmap.yaml
+++ b/kubernetes/postgres-configmap.yaml
@@ -7,11 +7,20 @@ data:
   init-data.sh: |
     #!/bin/bash
     set -e;
+
+    psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+      CREATE EXTENSION IF NOT EXISTS pgcrypto;
+    EOSQL
+
     if [ -n "${POSTGRES_NON_ROOT_USER:-}" ] && [ -n "${POSTGRES_NON_ROOT_PASSWORD:-}" ]; then
-    	psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
-    		CREATE USER "${POSTGRES_NON_ROOT_USER}" WITH PASSWORD '${POSTGRES_NON_ROOT_PASSWORD}';
-    		GRANT ALL PRIVILEGES ON DATABASE ${POSTGRES_DB} TO "${POSTGRES_NON_ROOT_USER}";
-    	EOSQL
+      if [ "$POSTGRES_NON_ROOT_USER" != "$POSTGRES_USER" ]; then
+        psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+          CREATE USER "${POSTGRES_NON_ROOT_USER}" WITH PASSWORD '${POSTGRES_NON_ROOT_PASSWORD}';
+          GRANT ALL PRIVILEGES ON DATABASE ${POSTGRES_DB} TO "${POSTGRES_NON_ROOT_USER}";
+        EOSQL
+      else
+        echo "SETUP INFO: Non-root user is the same as root user, skipping creation."
+      fi
     else
-    	echo "SETUP INFO: No Environment variables given!"
+      echo "SETUP INFO: No Environment variables given!"
     fi

--- a/kubernetes/postgres-configmap.yaml
+++ b/kubernetes/postgres-configmap.yaml
@@ -15,9 +15,15 @@ data:
     if [ -n "${POSTGRES_NON_ROOT_USER:-}" ] && [ -n "${POSTGRES_NON_ROOT_PASSWORD:-}" ]; then
       if [ "$POSTGRES_NON_ROOT_USER" != "$POSTGRES_USER" ]; then
         psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
-          CREATE USER "${POSTGRES_NON_ROOT_USER}" WITH PASSWORD '${POSTGRES_NON_ROOT_PASSWORD}';
+          DO \$\$
+          BEGIN
+            CREATE USER "${POSTGRES_NON_ROOT_USER}" WITH PASSWORD '${POSTGRES_NON_ROOT_PASSWORD}';
+          EXCEPTION WHEN duplicate_object THEN
+            RAISE NOTICE 'User ${POSTGRES_NON_ROOT_USER} already exists, skipping creation.';
+          END
+          \$\$;
           GRANT ALL PRIVILEGES ON DATABASE ${POSTGRES_DB} TO "${POSTGRES_NON_ROOT_USER}";
-        EOSQL
+    EOSQL
       else
         echo "SETUP INFO: Non-root user is the same as root user, skipping creation."
       fi


### PR DESCRIPTION
**Description:**
This PR fixes an issue where the n8n pod would enter a `CrashLoopBackoff` state during startup due to a failed database migration. The migration `ChangeDefaultForIdInUserTable...` relies on the `gen_random_uuid()` function, which requires the `pgcrypto` extension to be enabled in the Postgres database.

**Problem:**
When deploying n8n to a fresh Kubernetes cluster (e.g., Minikube), the n8n pod would fail to start with the following error:

```
Migration "ChangeDefaultForIdInUserTable1762771264000" failed, error: function gen_random_uuid() does not exist
```

Additionally, the Postgres initialization script in `postgres-configmap.yaml` was not idempotent. If the pod restarted (e.g., due to a crash or manual delete), the script would fail with `ERROR: role "changeUser" already exists`, causing the container to exit or skip the rest of the initialization logic.

**Solution:**
Updated `kubernetes/postgres-configmap.yaml` to:
1.  **Enable `pgcrypto`**: Added `CREATE EXTENSION IF NOT EXISTS pgcrypto;` to the initialization script. This ensures the necessary functions for UUID generation are available for n8n migrations.
2.  **Improve Idempotency**: Added a check to verify if the non-root user is different from the root user before attempting to create it. This prevents the script from failing if the user already exists, ensuring that the extension creation and other setup steps can still run successfully on subsequent starts.

**Testing:**
-   Verified on a local Minikube cluster.
-   Deleted the `n8n` namespace and all persistent volumes.
-   Applied the updated manifests.
-   Confirmed that both `postgresAdditionally, the Postgres initialization script in `postgres-configmap.yaml` was not idempotent. If the pod restarted (e.g., due to a crash or manual delete), the script would fail with `ERROR: role "changeUser" already exists`, causing the container to exit or skip the rest of the initialization logic.

**Solution:**
Updated `kubernetes/postgres-configmap.yaml` to:
1.  **Enable `pgcrypto`**: Added `CREATE EXTENSION IF NOT EXISTS pgcrypto;` to the initialization script. This ensures the necessary functions for UUID generation are available for n8n migrations.
2.  **Improve Idempotency**: Added a check to verify if the non-root user is different from the root user before attempting to create it. This prevents the script from failing if the user already exists, ensuring that the extension creation and other setup steps can still run successfully on subsequent starts.

**Testing:**
-   Verified on a local Minikube cluster.
-   Deleted the `n8n` namespace and all persistent volumes.
-   Applied the updated manifests.
-   Confirmed that both `postgres` and `n8n` pods started successfully (Running status).
-   Verified in n8n logs that migrations completed without errors.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable pgcrypto in the Postgres init script and make user creation idempotent to stop n8n CrashLoopBackoff during migrations. Fixes the “gen_random_uuid() does not exist” error on fresh Kubernetes installs.

- **Bug Fixes**
  - Create pgcrypto extension if missing to support gen_random_uuid() used by migrations.
  - Skip non-root user creation when it matches POSTGRES_USER to keep init safe on restarts.

<sup>Written for commit 7a77e930b8561481c8a7b4a490db70c724a84b7a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



