### PR TITLE
fix(ci): remove non-existent 'automated' label from bump workflow

### DIFF
--- a/.github/workflows/bump-n8n-version.yml
+++ b/.github/workflows/bump-n8n-version.yml
@@ -110,5 +110,4 @@ jobs:
 
           > This PR was created automatically by the [bump-n8n-version](.github/workflows/bump-n8n-version.yml) workflow.
           EOF
-          )" \
-            --label "automated"
+          )"


### PR DESCRIPTION
## Summary

- The `--label "automated"` flag on `gh pr create` fails because the label doesn't exist in the repo
- This caused the weekly n8n version bump workflow to report failure even though the PR was created successfully
- Removing the label flag fixes the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)