### PR TITLE
Bump n8n to 2.9.2

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -8,7 +8,7 @@ description: >-
   Production-grade Helm chart for n8n, the workflow automation platform.
   Supports queue mode, multi-main HA, webhook processors, task runners, HPA,
   PDB, network policies, and S3 external storage.
-appVersion: "2.9.0"
+appVersion: "2.9.2"
 type: application
 keywords:
   - n8n

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -1,7 +1,7 @@
 # ----- Image -----
 image:
   repository: docker.n8n.io/n8nio/n8n
-  tag: "2.9.0"
+  tag: "2.9.2"
   pullPolicy: IfNotPresent
 
 # ----- Names -----


### PR DESCRIPTION
## Summary

Automated bump of default n8n version from `2.9.0` to `2.9.2`.

- Updated `image.tag` in `values.yaml`
- Updated `appVersion` in `Chart.yaml`

Release notes: https://github.com/n8n-io/n8n/releases/tag/n8n%402.9.2

> This PR was created automatically by the [bump-n8n-version](.github/workflows/bump-n8n-version.yml) workflow.