### PR TITLE
fix(ci): add concurrency control to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,10 @@ permissions:
   packages: write
   pull-requests: write
 
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds `concurrency` group with `cancel-in-progress: false` to the release workflow
- When multiple PRs merge close together, the second release run now **queues and waits** instead of being lost
- Prevents the race condition that caused the n8n 2.9.2 bump to be missing from the v1.0.2 changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)