### PR TITLE
fix(ci): pin trivy-action to SHA for supply chain security

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.34.2
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.34.0+
         with:
           scan-type: fs
           scan-ref: charts/n8n


### PR DESCRIPTION
## Summary
- Pins `aquasecurity/trivy-action` from mutable tag `0.34.2` to immutable commit SHA `57a97c7e7821a5776cebc9bb87c984fa69cba8f1`
- Mitigates supply chain attack risk — tags can be moved by an attacker, SHAs cannot
- The pinned SHA corresponds to the "Update trivy to v0.69.3" commit (2026-03-04)

## Test plan
- [x] CI security-scan job runs successfully with the pinned SHA
- [ ] Trivy SARIF results are still uploaded correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)