### PR TITLE
fix(ci): correct trivy-action version comment to v0.35.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.34.0+
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: fs
           scan-ref: charts/n8n


### PR DESCRIPTION
## Summary
- Fixes the version comment on the pinned trivy-action SHA from `v0.34.0+` to `v0.35.0`
- No functional change — the SHA pin is unchanged

## Test plan
- [x] CI passes (comment-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)