### PR TITLE
docs(chart): add task runner sidecar example and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
           - charts/n8n/examples/minimal.yaml
           - charts/n8n/examples/minimal-with-docker.yaml
           - charts/n8n/examples/multi-main-queue.yaml
+          - charts/n8n/examples/task-runners.yaml
           - charts/n8n/examples/production-s3.yaml
     steps:
       - uses: actions/checkout@v4

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -58,6 +58,7 @@ All three use the same n8n container image, differentiated by command/args.
 | [minimal.yaml](./examples/minimal.yaml) | Single main pod, minimum config |
 | [minimal-with-docker.yaml](./examples/minimal-with-docker.yaml) | Quick testing with Docker Postgres/Redis |
 | [multi-main-queue.yaml](./examples/multi-main-queue.yaml) | Multi-main HA (Enterprise license required) |
+| [task-runners.yaml](./examples/task-runners.yaml) | Queue mode with task runner sidecars |
 | [production-s3.yaml](./examples/production-s3.yaml) | Production with S3, HPA, multi-main |
 
 ## Secret Management
@@ -86,6 +87,29 @@ For production, use an external secrets operator (e.g., [External Secrets Operat
 | `networkPolicy.enabled` | Network policies | `false` |
 
 See [values.yaml](./values.yaml) for the full list of configurable values.
+
+## Task Runners
+
+Task runners execute user-provided JavaScript and Python code in isolated sidecar containers, separate from the main n8n process. When enabled, each main and worker pod gets a runner sidecar.
+
+**How it works:** The n8n container runs a task broker on port 5679. The runner sidecar connects to this broker over localhost to receive and execute code tasks.
+
+**Enable task runners:**
+```yaml
+taskRunners:
+  enabled: true
+  authToken:
+    existingSecret: "n8n-runner-token"
+    existingSecretKey: "auth-token"
+```
+
+Create the auth token secret:
+```bash
+kubectl create secret generic n8n-runner-token \
+  --from-literal=auth-token=$(openssl rand -base64 32)
+```
+
+See [task-runners.yaml](./examples/task-runners.yaml) for a complete example including resource tuning and Python runner support.
 
 ## Upgrading
 

--- a/charts/n8n/examples/README.md
+++ b/charts/n8n/examples/README.md
@@ -9,6 +9,9 @@ This directory contains common configuration examples for different deployment s
 - **[minimal.yaml](./minimal.yaml)** - Single main pod with external PostgreSQL and Redis
 - **[minimal-with-docker.yaml](./minimal-with-docker.yaml)** - Quick testing with Docker containers
 
+### Community Examples (Task Runners)
+- **[task-runners.yaml](./task-runners.yaml)** - Queue mode with task runner sidecars for JavaScript/Python execution
+
 ### Enterprise Examples (License Required)
 - **[production-s3.yaml](./production-s3.yaml)** - Production setup with multi-main, webhooks, S3 storage, and autoscaling
 - **[multi-main-queue.yaml](./multi-main-queue.yaml)** - Multi-main and queue mode configuration

--- a/charts/n8n/examples/task-runners.yaml
+++ b/charts/n8n/examples/task-runners.yaml
@@ -1,0 +1,97 @@
+# Task Runners with Queue Mode
+# This example demonstrates enabling task runner sidecars for external code execution
+# Task runners handle JavaScript and Python execution in isolated sidecar containers
+#
+# Architecture:
+#   - The n8n container runs a task broker on port 5679
+#   - A runner sidecar container connects to the broker over localhost
+#   - Both main and worker pods get their own runner sidecar
+#
+# Prerequisites:
+#   - External PostgreSQL and Redis (queue mode)
+#   - A shared auth token secret for runner ↔ broker communication
+
+queueMode:
+  enabled: true
+  workerReplicaCount: 3
+  workerConcurrency: 10
+
+# Enable task runner sidecars on main and worker pods
+taskRunners:
+  enabled: true
+
+  # Auth token for runner ↔ broker communication
+  # Create the secret first:
+  #   kubectl create secret generic n8n-runner-token --from-literal=auth-token=$(openssl rand -base64 32)
+  authToken:
+    existingSecret: "n8n-runner-token"
+    existingSecretKey: "auth-token"
+
+  # Broker runs inside the n8n container
+  broker:
+    listenAddress: "0.0.0.0"
+    port: 5679
+
+  # Launcher settings
+  launcher:
+    logLevel: info
+    autoShutdownTimeout: 15
+
+  # Enable Python runner support
+  nativePythonRunner: true
+
+  # Resource limits for runner sidecar (tune based on workflow complexity)
+  resources:
+    requests:
+      cpu: 200m
+      memory: 512Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+
+  # Optional: mount a custom config to allowlist additional npm packages
+  # customConfig:
+  #   enabled: true
+  #   configMapName: "n8n-runner-config"
+  #   configMapKey: "n8n-task-runners.json"
+
+# External database
+database:
+  type: postgresdb
+  useExternal: true
+  host: "your-postgres-host.com"
+  port: 5432
+  database: n8n
+  schema: "public"
+  user: n8n
+  passwordSecret:
+    name: "n8n-db-secret"
+    key: "password"
+
+# External Redis
+redis:
+  enabled: true
+  useExternal: true
+  host: "your-redis-host.com"
+  port: 6379
+
+# Core secrets
+secretRefs:
+  existingSecret: "n8n-core-secrets"
+
+# Resource limits for n8n containers
+resources:
+  main:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      cpu: "2"
+      memory: 2Gi
+  worker:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      cpu: "2"
+      memory: 2Gi


### PR DESCRIPTION
## Summary
- Adds `charts/n8n/examples/task-runners.yaml` showing queue mode with task runner sidecars for JavaScript/Python execution
- Adds "Task Runners" section to the Helm chart README explaining sidecar architecture and setup
- Updates examples README with the new example
- Adds the new example to CI template validation matrix

## Context
The Helm chart already supports task runners in code (`taskRunners:` in values.yaml, sidecar injection in deployment templates), but there were no examples or documentation showing users how to enable them. This addresses customer pain around deploying runners in Kubernetes beyond basic Docker Compose samples.

## Test plan
- [x] `helm template test charts/n8n -f charts/n8n/examples/task-runners.yaml` renders successfully
- [x] CI template-validation job passes with the new example
- [x] Existing examples still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)