### PR TITLE
feat(chart): support independent service annotations for main and webhook-processor

### DIFF
--- a/charts/n8n/templates/service-main.yaml
+++ b/charts/n8n/templates/service-main.yaml
@@ -5,8 +5,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
+  {{- $merged := merge (deepCopy (.Values.service.main.annotations | default dict)) (.Values.service.annotations | default dict) }}
+  {{- with $merged }}
   annotations:
-    {{- with .Values.service.annotations }}{{ toYaml . | nindent 4 }}{{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   selector:

--- a/charts/n8n/templates/service-webhook-processor.yaml
+++ b/charts/n8n/templates/service-webhook-processor.yaml
@@ -7,7 +7,8 @@ metadata:
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
     app.kubernetes.io/component: webhook-processor
-  {{- with .Values.service.annotations }}
+  {{- $merged := merge (deepCopy (.Values.service.webhookProcessor.annotations | default dict)) (.Values.service.annotations | default dict) }}
+  {{- with $merged }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -123,6 +123,10 @@ service:
   type: ClusterIP
   port: 5678
   annotations: {}
+  main:
+    annotations: {}
+  webhookProcessor:
+    annotations: {}
   sessionAffinity:
     enabled: false
     timeoutSeconds: 10800


### PR DESCRIPTION
## Summary
- Adds `service.main.annotations` and `service.webhookProcessor.annotations` to allow independent annotation configuration per service
- Per-service annotations are merged on top of the existing global `service.annotations`, with per-service values taking precedence on conflict
- Fully backward compatible — existing `service.annotations` behavior is unchanged

Closes #94

## Test plan
- [x] `helm template` with no overrides — no annotations rendered
- [x] `service.annotations` only — both services get the annotation (backward compat)
- [x] `service.main.annotations` only — only main service gets it
- [x] `service.webhookProcessor.annotations` only — only webhook-processor gets it
- [x] Both global and per-service set with conflicting key — per-service wins

🤖 Generated with [Claude Code](https://claude.com/claude-code)