### PR TITLE
fix: correct Traefik PathPrefix rule and remove stale vendor-branch refs

### DIFF
--- a/docker-compose/subfolderWithSSL/docker-compose.yml
+++ b/docker-compose/subfolderWithSSL/docker-compose.yml
@@ -32,10 +32,9 @@ services:
       - '127.0.0.1:5678:5678'
     labels:
       - traefik.enable=true
-      - traefik.http.routers.n8n.rule=Host(`${DOMAIN_NAME}`)
+      - 'traefik.http.routers.n8n.rule=Host(`${DOMAIN_NAME}`) && PathPrefix(`/${SUBFOLDER}`)'
       - traefik.http.routers.n8n.tls=true
       - traefik.http.routers.n8n.entrypoints=websecure
-      - 'traefik.http.routers.n8n.rule=PathPrefix(`/${SUBFOLDER}{regex:$$|/.*}`)'
       - 'traefik.http.middlewares.n8n-stripprefix.stripprefix.prefixes=/${SUBFOLDER}'
       - 'traefik.http.routers.n8n.middlewares=n8n-stripprefix'
       - traefik.http.routers.n8n.tls.certresolver=mytlschallenge

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -23,8 +23,4 @@ n8n recommends self-hosting for expert users. Mistakes can lead to data loss, se
 
 ## Contributions
 
-For common changes, please open a PR to `main` branch and we will merge this
-into cloud provider specific branches.
-
-If you have a contribution specific to a cloud provider, please open your PR to
-the relevant branch.
+Please open PRs to the `main` branch.


### PR DESCRIPTION
## Summary
- **Fix Traefik subfolder routing (#12):** The `subfolderWithSSL` docker-compose had a duplicate `traefik.http.routers.n8n.rule` label (the second overwrote the first, losing the Host match) and a broken regex pattern causing 404s. Combined Host + PathPrefix into a single rule and removed the regex.
- **Remove stale vendor-branch references (#44):** The Kubernetes README referenced cloud-provider-specific branches that no longer exist. Simplified the contribution section to direct PRs to `main`.

Closes #12
Closes #44

## Test plan
- [x] Verify the `subfolderWithSSL` docker-compose starts correctly with Traefik routing to the configured subfolder
- [x] Confirm the Kubernetes README no longer references non-existent branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)