### PR TITLE
fix(chart): allow workerReplicaCount=0 for migration-only deploys

### DIFF
--- a/charts/n8n/templates/_helpers.tpl
+++ b/charts/n8n/templates/_helpers.tpl
@@ -84,7 +84,7 @@ Validate values — called once from deployment-main.yaml to fail fast on bad co
 {{/* --- Standalone mode constraints --- */}}
 {{- if not .Values.queueMode.enabled -}}
 {{- if not .Values.persistence.enabled -}}
-{{- fail "persistence.enabled must be true when queueMode.enabled=false. Standalone mode uses SQLite which requires persistent storage." -}}
+{{- fail "persistence.enabled must be true when queueMode.enabled=false. Standalone mode requires persistent storage." -}}
 {{- end -}}
 {{- if .Values.multiMain.enabled -}}
 {{- fail "multiMain.enabled=true requires queueMode.enabled=true" -}}

--- a/charts/n8n/templates/deployment-worker.yaml
+++ b/charts/n8n/templates/deployment-worker.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.queueMode.enabled -}}
+{{- if and .Values.queueMode.enabled (gt (int .Values.queueMode.workerReplicaCount) 0) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/n8n/templates/hpa-worker.yaml
+++ b/charts/n8n/templates/hpa-worker.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.hpa.worker.enabled .Values.queueMode.enabled (not .Values.keda.enabled) }}
+{{- if and .Values.hpa.worker.enabled .Values.queueMode.enabled (gt (int .Values.queueMode.workerReplicaCount) 0) (not .Values.keda.enabled) }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/n8n/templates/scaledobject-worker.yaml
+++ b/charts/n8n/templates/scaledobject-worker.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.keda.enabled .Values.queueMode.enabled }}
+{{- if and .Values.keda.enabled .Values.queueMode.enabled (gt (int .Values.queueMode.workerReplicaCount) 0) }}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:

--- a/charts/n8n/values.schema.json
+++ b/charts/n8n/values.schema.json
@@ -148,7 +148,7 @@
       "type": "object",
       "properties": {
         "enabled": { "type": "boolean" },
-        "workerReplicaCount": { "type": "integer", "minimum": 1 }
+        "workerReplicaCount": { "type": "integer", "minimum": 0 }
       }
     },
     "service": {


### PR DESCRIPTION
## Summary

- Allow `queueMode.workerReplicaCount` to be set to `0` so operators can run only the main pod during initial deployment or database migrations (e.g. for databases like YugabyteDB that need single-process migration)
- Skip rendering the worker Deployment entirely when replicas is 0, rather than creating a 0-replica Deployment
- Fix inaccurate "uses SQLite" claim in the standalone-mode persistence validation message

## Test plan

- [x] `helm template` with `workerReplicaCount=0` succeeds with no worker deployment rendered
- [x] `helm template` with `workerReplicaCount=2` continues to render worker deployment normally
- [x] `helm template` with `queueMode.enabled=false, persistence.enabled=false` shows corrected validation message

🤖 Generated with [Claude Code](https://claude.com/claude-code)