### PR TITLE
feat(chart): allow configuring Deployment strategy

### DIFF
--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -83,6 +83,7 @@ For production, use an external secrets operator (e.g., [External Secrets Operat
 | `taskRunners.enabled` | Task runner sidecars | `false` |
 | `ingress.enabled` | Create Ingress resource | `false` |
 | `persistence.enabled` | PVC for main pods | `false` |
+| `strategy` | Deployment update strategy | `{}` (k8s default) |
 | `hpa.main.enabled` | HPA for main pods | `false` |
 | `hpa.worker.enabled` | HPA for worker pods | `false` |
 | `keda.enabled` | KEDA queue-based autoscaling | `false` |

--- a/charts/n8n/templates/deployment-main.yaml
+++ b/charts/n8n/templates/deployment-main.yaml
@@ -10,6 +10,10 @@ metadata:
 spec:
   replicas: {{ ternary .Values.multiMain.replicas .Values.replicaCount .Values.multiMain.enabled }}
   revisionHistoryLimit: 3
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "n8n.name" . }}

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -115,6 +115,11 @@ taskRunners:
   #   - name: N8N_RUNNERS_LAUNCHER_LOG_LEVEL
   #     value: debug
 
+# ----- Deployment Strategy -----
+# Set to { type: Recreate } when using persistence with a RWO PVC (e.g. SQLite)
+# to avoid Multi-Attach errors during upgrades.
+strategy: {}
+
 # ----- Main replicas (when multi-main is disabled) -----
 replicaCount: 1
 


### PR DESCRIPTION
## Summary
- Adds a `strategy` value to the main Deployment template so users can configure the update strategy (e.g. `Recreate` vs `RollingUpdate`)
- Fixes Multi-Attach errors during `helm upgrade` when using SQLite with a RWO PersistentVolumeClaim
- Defaults to `{}` (no change to existing behavior)

Closes #106

## Changes
- `charts/n8n/values.yaml` — new `strategy: {}` with explanatory comment
- `charts/n8n/templates/deployment-main.yaml` — `{{- with .Values.strategy }}` block
- `charts/n8n/README.md` — new row in Key Configuration table

## Test plan
- [x] `helm template` with default values — no strategy field rendered (unchanged behavior)
- [x] `helm template --set strategy.type=Recreate` — strategy block appears on main deployment only
- [ ] Deploy with `strategy.type: Recreate` and verify `helm upgrade` works with RWO PVC

🤖 Generated with [Claude Code](https://claude.com/claude-code)