### PR TITLE
fix: broken form trigger and download binary from s3

### DIFF
--- a/charts/n8n/examples/README.md
+++ b/charts/n8n/examples/README.md
@@ -192,12 +192,16 @@ webhookProcessor:
 
 When `disableProductionWebhooksOnMainProcess: true`, configure your load balancer to route:
 - `/webhook/*` → webhook processor service (production webhooks)
-- `/webhook-test/*` → main service (test webhooks)  
+- `/form/*` → webhook processor service (production form triggers)
+- `/form-waiting/*` → webhook processor service (waiting form pages)
+- `/webhook-test/*` → main service (test webhooks)
+- `/form-test/*` → main service (test form triggers)
 - `/*` → main service (UI, API, everything else)
 
 ### Testing
 ```bash
 curl -i http://your-domain/webhook/test-id      # Should reach webhook processor
+curl -i http://your-domain/form/test-id         # Should reach webhook processor
 curl -i http://your-domain/webhook-test/test-id # Should reach main service
 ```
 

--- a/charts/n8n/examples/production-s3.yaml
+++ b/charts/n8n/examples/production-s3.yaml
@@ -13,7 +13,7 @@ queueMode:
   workerReplicaCount: 5
   workerConcurrency: 15
 
-# Load balancer must route /webhook/* to webhook processor service
+# Load balancer must route /webhook/*, /form/*, and /form-waiting/* to webhook processor service
 webhookProcessor:
   enabled: true
   replicaCount: 2

--- a/charts/n8n/templates/deployment-webhook-processor.yaml
+++ b/charts/n8n/templates/deployment-webhook-processor.yaml
@@ -68,10 +68,10 @@ spec:
           env:
             # Shared configuration from ConfigMap
             {{- include "n8n.sharedConfigMapEnv" . | nindent 12 }}
-            
+
             # Webhook processor-specific configuration from ConfigMap
             {{- include "n8n.webhookProcessorConfigMapEnv" . | nindent 12 }}
-            
+
             # Database password (secret)
             - name: DB_POSTGRESDB_PASSWORD
               valueFrom:
@@ -88,12 +88,12 @@ spec:
                   key: {{ .key }}
             {{- end }}
             {{- end }}
-            
+
             # Redis-specific extra environment variables
             {{- with .Values.redis.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-            
+
             # Webhook-specific extra environment variables
             {{- with .Values.webhook.extraEnv }}
             {{- toYaml . | nindent 12 }}
@@ -134,6 +134,9 @@ spec:
                 secretKeyRef:
                   name: {{ if .Values.secretRefs.existingSecret }}{{ .Values.secretRefs.existingSecret }}{{ else }}{{ include "n8n.fullname" . }}{{ end }}
                   key: N8N_PROTOCOL
+
+            # S3 External Storage
+            {{- include "n8n.s3Env" . | nindent 12 }}
 
             {{- with .Values.config.extraEnv }}
             {{- toYaml . | nindent 12 }}

--- a/charts/n8n/templates/ingress-webhook.yaml
+++ b/charts/n8n/templates/ingress-webhook.yaml
@@ -34,6 +34,20 @@ spec:
                 name: {{ include "n8n.fullname" $ }}-webhook-processor
                 port:
                   number: {{ $.Values.service.port }}
+          - path: /form/
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "n8n.fullname" $ }}-webhook-processor
+                port:
+                  number: {{ $.Values.service.port }}
+          - path: /form-waiting/
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "n8n.fullname" $ }}-webhook-processor
+                port:
+                  number: {{ $.Values.service.port }}
   {{- end }}
   {{- with (.Values.ingress.webhookProcessor).tls }}
   tls:


### PR DESCRIPTION
# Pull Request

## Description
fix form trigger in queue mode

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Example/configuration update
- [ ] CI/CD improvements

## Related Issues
Fixes #114 

## Changes Made
- add s3 env to webhook pod
- include `/form/` and `/form-wating/` to webhook ingress

## Testing Performed

### Chart Validation
- [ ] `helm lint charts/n8n` passes
- [ ] `./scripts/validate-examples.sh` passes
- [ ] Template rendering works with all examples

### Deployment Testing (if applicable)
- [ ] Tested with minimal configuration
- [x] Tested with production configuration
- [x] Tested upgrade path from previous version
- [x] All pods start successfully
- [x] Application is accessible

### Specific Testing for Changes

## Breaking Changes

## Documentation Updates
- [ ] Updated Chart.yaml version (if needed)
- [ ] Updated CHANGELOG.md
- [ ] Updated README.md (if needed)
- [ ] Updated examples (if needed)
- [ ] Updated CONTRIBUTING.md (if needed)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have added examples that demonstrate the changes (if applicable)
- [ ] All new and existing tests pass

## Screenshots (if applicable)

## Additional Notes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken form triggers in queue mode and restores S3 binary downloads, with docs clarifying required form routing. Fixes #114.

- **Bug Fixes**
  - Injects S3 external storage env into the webhook processor so form endings can fetch binaries.
  - Routes `/form/` and `/form-waiting/` to the webhook processor; updates examples and README to document these paths.

<sup>Written for commit 6839f2865aa3e9caeb8c0c072021db4e36efb530. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

