### PR TITLE
fix(chart): fail fast when serviceAccount.create=false with default name

### DIFF
--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -70,6 +70,18 @@ All three use the same n8n container image, differentiated by command/args.
 
 For production, use an external secrets operator (e.g., [External Secrets Operator](https://external-secrets.io/)) rather than storing secrets in values files.
 
+## ServiceAccount
+
+By default the chart creates a ServiceAccount named `n8n`. To use an externally-managed ServiceAccount (e.g. one created by Terraform for IRSA), set `serviceAccount.create: false` **and** change `serviceAccount.name` to the name of the existing SA:
+
+```yaml
+serviceAccount:
+  create: false
+  name: "my-external-sa"   # must already exist in the release namespace
+```
+
+To use the namespace's default ServiceAccount, set `name: ""`. If you set `create: false` without also changing `name` from the chart default `"n8n"`, rendering will fail with a clear error — this prevents pods from being wired to a ServiceAccount that was never created.
+
 ## Key Configuration
 
 | Value | Description | Default |

--- a/charts/n8n/templates/_helpers.tpl
+++ b/charts/n8n/templates/_helpers.tpl
@@ -135,4 +135,9 @@ Validate values — called once from deployment-main.yaml to fail fast on bad co
 {{- fail "secretRefs.env.N8N_ENCRYPTION_KEY must be changed from the default placeholder value, or provide secretRefs.existingSecret with your own Secret" -}}
 {{- end -}}
 
+{{/* --- Service account --- */}}
+{{- if and (not .Values.serviceAccount.create) (eq .Values.serviceAccount.name "n8n") -}}
+{{- fail "serviceAccount.create=false but serviceAccount.name is still the chart default \"n8n\". Set serviceAccount.name to your pre-existing ServiceAccount, or to \"\" to use the namespace's default ServiceAccount." -}}
+{{- end -}}
+
 {{- end -}}

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -230,19 +230,24 @@ rbac:
 serviceAccount:
   # Create a new service account for n8n pods
   create: true
-  # Service account name - supports multiple configuration scenarios:
+  # Service account name — supports multiple configuration scenarios:
   #
   # 1. Create new service account (default):
   #    create: true
-  #    name: "n8n"  # <-- Custom name, or leave empty to use chart fullname
+  #    name: "n8n"   # <-- chart creates this SA; leave empty to use chart fullname
   #
-  # 2. Use existing/managed service account (e.g., created by Terraform):
+  # 2. Use an existing/externally-managed service account (e.g., Terraform, IRSA):
   #    create: false
-  #    name: "my-terraform-service-account"
+  #    name: "my-external-service-account"   # <-- MUST exist in the namespace
   #
-  # 3. Use no service account (pods run with default permissions):
+  # 3. Use the namespace's default service account:
   #    create: false
-  #    name: ""  # <-- Empty or omit entirely
+  #    name: ""   # <-- empty; pods inherit the namespace "default" SA
+  #
+  # IMPORTANT: if you set create: false, you MUST also change `name` from the
+  # default "n8n" — otherwise pods will reference a ServiceAccount that was
+  # never created and fail to start. The chart will refuse to render in that
+  # case (see n8n.validate in templates/_helpers.tpl).
   name: n8n
   # AWS IAM Role ARN for IRSA (IAM Roles for Service Accounts)
   # Required when s3.auth.autoDetect=true for AWS S3 access


### PR DESCRIPTION
## Summary
- Fixes #113. If you set `serviceAccount.create: false` without also changing `serviceAccount.name` from the default `"n8n"`, pods reference a SA that the chart never created and fail to schedule. Nothing in the chart warns you.
- Adds a `n8n.validate` guard so this combination fails at render time with a clear message telling you what to do.
- Cleans up the `serviceAccount` comment block in `values.yaml` and adds a short ServiceAccount section to the chart README covering the four supported configurations.
- No breaking changes: default SA name stays `n8n`, existing installs are unaffected.

## Test plan
- [x] `helm lint charts/n8n` — clean
- [x] `helm template` renders correctly for: `create=true/name=n8n`, `create=false/name=my-external-sa`, and `create=false/name=""`
- [x] `helm template` for the footgun case (`create=false` with default name) fails with the expected error
- [x] Real `helm install` into OrbStack with `create=false/name=""` — pod scheduled with `serviceAccountName=default`
- [x] Real `helm install` with the footgun combo — blocked at install with the validation message

🤖 Generated with [Claude Code](https://claude.com/claude-code)