### PR TITLE
feat(chart): add podLabels for extra labels on pod templates

### DIFF
--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -96,6 +96,7 @@ To use the namespace's default ServiceAccount, set `name: ""`. If you set `creat
 | `ingress.enabled` | Create Ingress resource | `false` |
 | `persistence.enabled` | PVC for main pods | `false` |
 | `strategy` | Deployment update strategy | `{}` (k8s default) |
+| `podLabels` | Extra labels on every pod template | `{}` |
 | `hpa.main.enabled` | HPA for main pods | `false` |
 | `hpa.worker.enabled` | HPA for worker pods | `false` |
 | `keda.enabled` | KEDA queue-based autoscaling | `false` |

--- a/charts/n8n/templates/_helpers.tpl
+++ b/charts/n8n/templates/_helpers.tpl
@@ -140,4 +140,13 @@ Validate values — called once from deployment-main.yaml to fail fast on bad co
 {{- fail "serviceAccount.create=false but serviceAccount.name is still the chart default \"n8n\". Set serviceAccount.name to your pre-existing ServiceAccount, or to \"\" to use the namespace's default ServiceAccount." -}}
 {{- end -}}
 
+{{/* --- Pod labels --- */}}
+{{/* The chart manages a fixed set of pod-template labels (selector + recommended labels). Reject user-supplied podLabels that overlap them so we don't break the Deployment selector or produce duplicate YAML keys. */}}
+{{- $reservedPodLabels := list "app.kubernetes.io/name" "app.kubernetes.io/instance" "app.kubernetes.io/component" "app.kubernetes.io/version" "app.kubernetes.io/managed-by" "helm.sh/chart" -}}
+{{- range $k, $_ := .Values.podLabels -}}
+{{- if has $k $reservedPodLabels -}}
+{{- fail (printf "podLabels.%q is a chart-managed selector/identity label and cannot be overridden. Reserved keys: %s" $k (join ", " $reservedPodLabels)) -}}
+{{- end -}}
+{{- end -}}
+
 {{- end -}}

--- a/charts/n8n/templates/_helpers.tpl
+++ b/charts/n8n/templates/_helpers.tpl
@@ -141,11 +141,14 @@ Validate values — called once from deployment-main.yaml to fail fast on bad co
 {{- end -}}
 
 {{/* --- Pod labels --- */}}
-{{/* The chart manages a fixed set of pod-template labels (selector + recommended labels). Reject user-supplied podLabels that overlap them so we don't break the Deployment selector or produce duplicate YAML keys. */}}
+{{/* The chart manages a fixed set of pod-template labels (selector + recommended labels). Reject user-supplied podLabels that overlap them so we don't break the Deployment selector or produce duplicate YAML keys. Also enforce that values are strings — Kubernetes labels are map[string]string, so non-string values would fail API validation at deploy time; catch it at template time with a clearer message. */}}
 {{- $reservedPodLabels := list "app.kubernetes.io/name" "app.kubernetes.io/instance" "app.kubernetes.io/component" "app.kubernetes.io/version" "app.kubernetes.io/managed-by" "helm.sh/chart" -}}
-{{- range $k, $_ := .Values.podLabels -}}
+{{- range $k, $v := .Values.podLabels -}}
 {{- if has $k $reservedPodLabels -}}
 {{- fail (printf "podLabels.%q is a chart-managed selector/identity label and cannot be overridden. Reserved keys: %s" $k (join ", " $reservedPodLabels)) -}}
+{{- end -}}
+{{- if not (kindIs "string" $v) -}}
+{{- fail (printf "podLabels.%q must be a string (got %s). Kubernetes labels are map[string]string; quote numeric or boolean values, e.g. %q: \"true\"." $k (kindOf $v) $k) -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/n8n/templates/deployment-main.yaml
+++ b/charts/n8n/templates/deployment-main.yaml
@@ -30,6 +30,9 @@ spec:
       labels:
         {{- include "n8n.labels" . | nindent 8 }}
         app.kubernetes.io/component: main
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with include "n8n.serviceAccountName" . }}
       serviceAccountName: {{ . }}

--- a/charts/n8n/templates/deployment-webhook-processor.yaml
+++ b/charts/n8n/templates/deployment-webhook-processor.yaml
@@ -26,6 +26,9 @@ spec:
       labels:
         {{- include "n8n.labels" . | nindent 8 }}
         app.kubernetes.io/component: webhook-processor
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with include "n8n.serviceAccountName" . }}
       serviceAccountName: {{ . }}

--- a/charts/n8n/templates/deployment-worker.yaml
+++ b/charts/n8n/templates/deployment-worker.yaml
@@ -26,6 +26,9 @@ spec:
       labels:
         {{- include "n8n.labels" . | nindent 8 }}
         app.kubernetes.io/component: worker
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with include "n8n.serviceAccountName" . }}
       serviceAccountName: {{ . }}

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -120,6 +120,15 @@ taskRunners:
 # to avoid Multi-Attach errors during upgrades.
 strategy: {}
 
+# ----- Pod Labels -----
+# Extra labels added to the main / worker / webhook-processor pod templates,
+# in addition to the chart's own selector labels. Useful for opt-in admission
+# webhooks (e.g. Azure AD Workload Identity's `azure.workload.identity/use=true`,
+# Istio's `sidecar.istio.io/inject=true`) and external scrape selectors.
+# podLabels:
+#   azure.workload.identity/use: "true"
+podLabels: {}
+
 # ----- Main replicas (when multi-main is disabled) -----
 replicaCount: 1
 

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -125,6 +125,12 @@ strategy: {}
 # in addition to the chart's own selector labels. Useful for opt-in admission
 # webhooks (e.g. Azure AD Workload Identity's `azure.workload.identity/use=true`,
 # Istio's `sidecar.istio.io/inject=true`) and external scrape selectors.
+#
+# Reserved keys (managed by the chart, will fail at install time if set here):
+# - app.kubernetes.io/{name,instance,component,version,managed-by}
+# - helm.sh/chart
+# These are part of the Deployment's selector or recommended-labels set;
+# overriding them would break selector matching or produce duplicate YAML keys.
 # podLabels:
 #   azure.workload.identity/use: "true"
 podLabels: {}


### PR DESCRIPTION
## Summary

Adds a top-level `podLabels` value that is merged into the pod template `metadata.labels` of the main, worker, and webhook-processor Deployments, in addition to the chart's own selector labels.

Mirrors the existing `podAnnotations` pattern. Default `{}` preserves existing behavior — the `{{- with }}` block renders nothing when the value is empty.

## Motivation

Several Kubernetes admission webhooks key off pod-level **labels** rather than annotations or service-account references, and have no other opt-in path:

- **Azure AD Workload Identity** injects federated-token env vars only when a pod carries `azure.workload.identity/use=true`.
- **Istio**, **Linkerd**, and similar service-mesh injectors gate on `sidecar.istio.io/inject=true`, `linkerd.io/inject=enabled`.
- External Prometheus scrape selectors and policy-as-code controllers often match on custom labels.

Today, deployments using this chart in any of those environments need a post-Helm `kubectl patch` workaround on each `helm upgrade`, because the pod templates only emit the chart's built-in selector labels and there's no way to add more from values. This PR closes that gap.

## Changes

- `charts/n8n/templates/deployment-main.yaml` — adds `{{- with .Values.podLabels }} ... {{- end }}` under pod template `metadata.labels`
- `charts/n8n/templates/deployment-worker.yaml` — same
- `charts/n8n/templates/deployment-webhook-processor.yaml` — same
- `charts/n8n/values.yaml` — `podLabels: {}` declaration with explanatory comment and commented usage examples
- `charts/n8n/README.md` — new row in Key Configuration table

Selector labels are unchanged: the `{{- with }}` block only adds to `template.metadata.labels`, not `selector.matchLabels` or `metadata.labels` on the Deployment itself, so existing rolled-out workloads pick up the new labels on their next pod-template change without selector mismatch.

## Test plan

- [x] `helm lint charts/n8n` — passes
- [x] `helm template foo charts/n8n --set podLabels.foo=bar --set 'podLabels.example=test' ...` confirms `foo: bar` and `example: test` land under pod template `metadata.labels` on all three Deployments (main, worker, webhook-processor) without disturbing selector labels
- [x] Default render (`podLabels: {}`) — output is unchanged from current behavior except for the unchanged base labels (verified via diff)

## Related

Same chart-affordance pattern as #111 (which added `strategy:` for the main Deployment in 1.4.0).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `podLabels` to merge extra labels into pod template metadata for the main, worker, and webhook-processor Deployments. Validates reserved keys and enforces string values; default `{}` keeps behavior unchanged.

- **New Features**
  - `podLabels` merged into pod template `metadata.labels` for main, worker, and webhook-processor.
  - Mirrors `podAnnotations`; empty `{}` renders nothing.
  - Leaves `selector.matchLabels` unchanged for safe rolling upgrades.

- **Bug Fixes**
  - Fail fast if any `podLabels` key overlaps chart-managed labels (`app.kubernetes.io/*`, `helm.sh/chart`).
  - Validate all `podLabels` values are strings to match Kubernetes `map[string]string` label requirements.

<sup>Written for commit a48404353c306428bef321bcc48d63d919ce1cfc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

