### PR TITLE
fix(chart): only set N8N_RUNNERS_MODE when task runners are enabled

### DIFF
--- a/charts/n8n/templates/_configmap-env.tpl
+++ b/charts/n8n/templates/_configmap-env.tpl
@@ -84,6 +84,7 @@ Environment variables from ConfigMap for all components
       name: {{ include "n8n.fullname" . }}
       key: OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS
 {{- end }}
+{{- if .Values.taskRunners.enabled }}
 - name: N8N_RUNNERS_MODE
   valueFrom:
     configMapKeyRef:
@@ -99,6 +100,7 @@ Environment variables from ConfigMap for all components
       name: {{ include "n8n.fullname" . }}-task-runners
       key: N8N_RUNNERS_AUTH_TOKEN
       {{- end }}
+{{- end }}
 {{- if .Values.queueMode.enabled }}
 {{- if .Values.redis.clusterNodes }}
 - name: QUEUE_BULL_REDIS_CLUSTER_NODES

--- a/charts/n8n/templates/configmap.yaml
+++ b/charts/n8n/templates/configmap.yaml
@@ -49,12 +49,10 @@ data:
   EXECUTIONS_MODE: "queue"
   OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS: "true"
   {{- end }}
-  # Task Runners configuration (shared across all pods)
-  # N8N_RUNNERS_ENABLED is deprecated in n8n 2.9+; runners are always active.
-  # Setting MODE to "external" prevents n8n from trying to launch internal runners
-  # (which would fail for Python since the n8n image lacks Python 3).
-  N8N_RUNNERS_MODE: {{ .Values.taskRunners.mode | quote }}
+  # Task runner configuration (only emitted when sidecars are enabled,
+  # otherwise n8n uses its built-in internal runner default).
   {{- if .Values.taskRunners.enabled }}
+  N8N_RUNNERS_MODE: {{ .Values.taskRunners.mode | quote }}
   N8N_RUNNERS_BROKER_LISTEN_ADDRESS: {{ .Values.taskRunners.broker.listenAddress | quote }}
   N8N_NATIVE_PYTHON_RUNNER: {{ ternary "true" "false" .Values.taskRunners.nativePythonRunner | quote }}
   {{- end }}


### PR DESCRIPTION
## Summary

- The chart's ConfigMap injected `N8N_RUNNERS_MODE=external` on every n8n pod regardless of whether `taskRunners.enabled` was `true`. With the default (`enabled: false`, no sidecar deployed), n8n waited indefinitely for an external runner that would never connect — hanging the JS/Python Code node on every default install.
- Gate `N8N_RUNNERS_MODE` (and the matching env-var references for `N8N_RUNNERS_MODE` / `N8N_RUNNERS_AUTH_TOKEN` in `_configmap-env.tpl`) on `taskRunners.enabled`. When the sidecar is not deployed, n8n now falls back to its built-in internal runner default and the JS Code node works out-of-the-box.
- `values.yaml` defaults are unchanged. With `taskRunners.enabled: true` everything renders identically to before.

Fixes [CAT-2987](https://linear.app/n8n/issue/CAT-2987/helm-chart-defaults-to-external-task-runner).

## Test plan

- [x] `helm lint charts/n8n` passes
- [x] `helm template ... ` (defaults) — renders no `N8N_RUNNERS_MODE` / `N8N_RUNNERS_BROKER_LISTEN_ADDRESS` / `N8N_NATIVE_PYTHON_RUNNER` / `N8N_RUNNERS_AUTH_TOKEN` on n8n pods
- [x] `helm template ... --set taskRunners.enabled=true` — all four runner env vars and the `task-runner` sidecar render on both main and worker
- [x] End-to-end install on OrbStack (standalone/SQLite, defaults): main pod becomes `Ready`, no `N8N_RUNNERS_*` env vars in pod, n8n logs show `Registered runner "JS Task Runner"` and the broker started internally

🤖 Generated with [Claude Code](https://claude.com/claude-code)