### PR TITLE
fix(chart): use readiness endpoint for liveness probe

### DIFF
--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -262,7 +262,7 @@ networkPolicy:
 probes:
   liveness:
     enabled: true
-    path: /healthz/readiness
+    path: /healthz/readiness # /healthz always returns ok; /healthz/readiness checks dependencies
     initialDelaySeconds: 30
     periodSeconds: 20
     timeoutSeconds: 5

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -262,7 +262,7 @@ networkPolicy:
 probes:
   liveness:
     enabled: true
-    path: /healthz
+    path: /healthz/readiness
     initialDelaySeconds: 30
     periodSeconds: 20
     timeoutSeconds: 5

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -262,7 +262,7 @@ networkPolicy:
 probes:
   liveness:
     enabled: true
-    path: /healthz/readiness # /healthz always returns ok; /healthz/readiness checks dependencies
+    path: /healthz/readiness  # /healthz always returns ok; /healthz/readiness checks dependencies
     initialDelaySeconds: 30
     periodSeconds: 20
     timeoutSeconds: 5


### PR DESCRIPTION
## Summary

- Changes `probes.liveness.path` from `/healthz` to `/healthz/readiness` so the liveness probe checks DB connectivity state
- Previously, `/healthz` always returned `{ status: 'ok' }` regardless of DB state, meaning K8s would never restart a pod whose DB connection pool had permanently failed
- `/healthz/readiness` checks `connectionState.connected`, `connectionState.migrated`, and that n8n is fully initialised

## Why

A permanently broken DB connection pool causes the pod to become a zombie — alive to K8s, dead to all requests. With `/healthz` as the liveness endpoint, K8s never restarts the pod. This was the root cause of a 17-hour customer outage (ipagency) where the DB recovered in minutes but n8n never reconnected.

With this change, if the DB connection remains broken for more than ~120s (6 failures × 20s period), K8s will restart the pod.

## Test plan

- [x] Deploy to a test cluster and verify pod starts and becomes healthy normally
- [x] Verify liveness probe fails and pod restarts when DB is made unavailable for >120s

Relates to: https://linear.app/n8n/issue/CAT-3021/switch-pod-liveness-monitoring-to-readiness-endpoint