### PR TITLE
feat(chart): add per-component extraEnv for worker and webhook-processor

### DIFF
--- a/charts/n8n/templates/deployment-webhook-processor.yaml
+++ b/charts/n8n/templates/deployment-webhook-processor.yaml
@@ -142,6 +142,11 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
 
+            {{- with .Values.webhookProcessor.extraEnv }}
+            # Webhook-processor-specific extra environment variables
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+
           {{- with .Values.config.extraEnvFrom }}
           envFrom:
             {{- toYaml . | nindent 12 }}

--- a/charts/n8n/templates/deployment-worker.yaml
+++ b/charts/n8n/templates/deployment-worker.yaml
@@ -128,6 +128,11 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
 
+            {{- with .Values.queueMode.workerExtraEnv }}
+            # Worker-specific extra environment variables
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+
           {{- with .Values.config.extraEnvFrom }}
           envFrom:
             {{- toYaml . | nindent 12 }}

--- a/charts/n8n/values.schema.json
+++ b/charts/n8n/values.schema.json
@@ -156,9 +156,10 @@
             "type": "object",
             "properties": {
               "name": { "type": "string", "minLength": 1 },
-              "value": { "type": "string" }
+              "value": { "type": "string" },
+              "valueFrom": { "type": "object" }
             },
-            "required": ["name", "value"]
+            "required": ["name"]
           }
         }
       }
@@ -175,9 +176,10 @@
             "type": "object",
             "properties": {
               "name": { "type": "string", "minLength": 1 },
-              "value": { "type": "string" }
+              "value": { "type": "string" },
+              "valueFrom": { "type": "object" }
             },
-            "required": ["name", "value"]
+            "required": ["name"]
           }
         }
       }

--- a/charts/n8n/values.schema.json
+++ b/charts/n8n/values.schema.json
@@ -148,7 +148,38 @@
       "type": "object",
       "properties": {
         "enabled": { "type": "boolean" },
-        "workerReplicaCount": { "type": "integer", "minimum": 0 }
+        "workerReplicaCount": { "type": "integer", "minimum": 0 },
+        "workerConcurrency": { "type": "integer", "minimum": 1 },
+        "workerExtraEnv": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": { "type": "string", "minLength": 1 },
+              "value": { "type": "string" }
+            },
+            "required": ["name", "value"]
+          }
+        }
+      }
+    },
+    "webhookProcessor": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "replicaCount": { "type": "integer", "minimum": 1 },
+        "disableProductionWebhooksOnMainProcess": { "type": "boolean" },
+        "extraEnv": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": { "type": "string", "minLength": 1 },
+              "value": { "type": "string" }
+            },
+            "required": ["name", "value"]
+          }
+        }
       }
     },
     "service": {

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -19,6 +19,13 @@ queueMode:
   workerReplicaCount: 2
   # Worker concurrency (number of jobs each worker can handle simultaneously)
   workerConcurrency: 10
+  # Additional environment variables injected into worker pods only.
+  # Use for worker-specific tuning that must not affect main or webhook-processor pods.
+  # Example:
+  # workerExtraEnv:
+  #   - name: N8N_CONCURRENCY_PRODUCTION_LIMIT
+  #     value: "10"
+  workerExtraEnv: []
 
 # ----- Webhook processors (optional scaling layer) -----
 webhookProcessor:
@@ -27,6 +34,12 @@ webhookProcessor:
   replicaCount: 2
   # Disable webhook processing in main process when webhook processors are enabled
   disableProductionWebhooksOnMainProcess: true
+  # Additional environment variables injected into webhook-processor pods only.
+  # Example:
+  # extraEnv:
+  #   - name: N8N_LOG_LEVEL
+  #     value: "debug"
+  extraEnv: []
 
 # ----- Multi-main (optional, requires queue mode) -----
 multiMain:

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -21,6 +21,7 @@ queueMode:
   workerConcurrency: 10
   # Additional environment variables injected into worker pods only.
   # Use for worker-specific tuning that must not affect main or webhook-processor pods.
+  # For env vars that should apply to all pods, use `config.extraEnv` instead.
   # Example:
   # workerExtraEnv:
   #   - name: N8N_CONCURRENCY_PRODUCTION_LIMIT
@@ -35,6 +36,9 @@ webhookProcessor:
   # Disable webhook processing in main process when webhook processors are enabled
   disableProductionWebhooksOnMainProcess: true
   # Additional environment variables injected into webhook-processor pods only.
+  # Use this when a variable must NOT also be set on the main pod.
+  # For webhook-related env vars that apply to both webhook-handling pods
+  # (main + webhook-processor), use `webhook.extraEnv` instead.
   # Example:
   # extraEnv:
   #   - name: N8N_LOG_LEVEL
@@ -413,7 +417,9 @@ webhook:
   url: ""
   # Timeout for webhook requests in milliseconds
   timeout: 120000
-  # Additional webhook environment variables
+  # Additional webhook-related environment variables.
+  # Applied to BOTH main and webhook-processor pods. For variables that should
+  # only apply to webhook-processor pods, use `webhookProcessor.extraEnv` instead.
   extraEnv: []
 
 # ----- Executions config -----


### PR DESCRIPTION
# Pull Request

## Description
\`config.extraEnv\` is applied to all three deployments. There is no way to inject
environment variables into workers only or webhook-processor pods only.

Common use cases:
- Set \`N8N_CONCURRENCY_PRODUCTION_LIMIT\` on workers without affecting main/webhook
- Configure \`NODE_OPTIONS \` on workers to increase --max-old-space-size without impacting main

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Example/configuration update
- [ ] CI/CD improvements

## Related Issues
Relates to T-62407

## Changes Made
| File | Change |
|---|---|
| \`values.yaml\` | Add \`queueMode.workerExtraEnv: []\` and \`webhookProcessor.extraEnv: []\` |
| \`deployment-worker.yaml\` | Render \`queueMode.workerExtraEnv\` after \`config.extraEnv\` |
| \`deployment-webhook-processor.yaml\` | Render \`webhookProcessor.extraEnv\` after \`config.extraEnv\` |

Both keys default to \`[]\` — no breaking change, no migration needed.
EOF

## Testing Performed

### Chart Validation
- [x] `helm lint charts/n8n` passes
- [ ] `./scripts/validate-examples.sh` passes
- [ ] Template rendering works with all examples

### Deployment Testing (if applicable)
- [ ] Tested with minimal configuration
- [x] Tested with production configuration
- [x] Tested upgrade path from previous version
- [x] All pods start successfully
- [x] Application is accessible

### Specific Testing for Changes
Tested with EKS and ECR on AWS.

## Breaking Changes
None

## Documentation Updates
- [ ] Updated Chart.yaml version (if needed)
- [ ] Updated CHANGELOG.md
- [ ] Updated README.md (if needed)
- [ ] Updated examples (if needed)
- [ ] Updated CONTRIBUTING.md (if needed)

## Checklist
- [ ] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added examples that demonstrate the changes (if applicable)
- [ ] All new and existing tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-component env injection to the Helm chart so you can target workers and webhook-processor without affecting the main pod. Defaults are empty, so no migration. Addresses T-62407’s need for worker-only settings like concurrency limits.

- New Features
  - Added `queueMode.workerExtraEnv` for worker pods, rendered after `config.extraEnv` and validated in `values.schema.json`.
  - Added `webhookProcessor.extraEnv` for webhook-processor pods, rendered after `config.extraEnv` and validated in `values.schema.json`.
  - Clarified `webhook.extraEnv` vs `webhookProcessor.extraEnv` in `values.yaml` comments, added `workerConcurrency` to the schema, and kept `config.extraEnv` global for all pods.

- Bug Fixes
  - Schema now allows `valueFrom` in `workerExtraEnv` and `webhookProcessor.extraEnv` (only `name` required), matching Kubernetes env behavior.

<sup>Written for commit b075aea9117682cd03138c57a59f6a3a59e59678. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

