### PR TITLE
fix(chart): emit EXECUTIONS_DATA_PRUNE_MAX_COUNT when set to 0

### DIFF
--- a/charts/n8n/templates/_environment-helpers.tpl
+++ b/charts/n8n/templates/_environment-helpers.tpl
@@ -76,10 +76,8 @@ Executions Configuration environment variables
 - name: EXECUTIONS_DATA_MAX_AGE
   value: "{{ .Values.executions.pruning.maxAge }}"
 {{- end }}
-{{- if .Values.executions.pruning.maxCount }}
 - name: EXECUTIONS_DATA_PRUNE_MAX_COUNT
   value: "{{ .Values.executions.pruning.maxCount }}"
-{{- end }}
 {{- if .Values.executions.pruning.hardDeleteBuffer }}
 - name: EXECUTIONS_DATA_HARD_DELETE_BUFFER
   value: "{{ .Values.executions.pruning.hardDeleteBuffer }}"


### PR DESCRIPTION
## Summary

- Fixes #123 — `executions.pruning.maxCount: 0` was silently dropped because Helm's `if` treats `0` as falsy. The env var was never emitted, so n8n fell back to its compiled-in default of `10000`, defeating the documented `0 = no limit` behavior.
- Drops the conditional so `EXECUTIONS_DATA_PRUNE_MAX_COUNT` is always emitted. The JSON schema (`integer, minimum: 0`) and the values.yaml default (`10000`) already guarantee the value is a valid integer, so the guard was vestigial.

## Why not `hasKey`?

The reporter suggested `{{- if hasKey .Values.executions.pruning "maxCount" }}`, but with a default of `10000` in `values.yaml`, helm's deep-merge always keeps the key present, so `hasKey` would return `true` regardless and add a misleading guard without changing behavior. Dropping the conditional outright is simpler and correct.

## Other pruning fields

`maxAge`, `hardDeleteBuffer`, `hardDeleteInterval`, `softDeleteInterval`, and `timeoutMax` use the same falsy pattern but their schema floors are `minimum: 1`, so `0` can never reach the template. Their guards are harmless and untouched here to keep the diff surgical.

## Behavior change

Only affects users who currently set `maxCount: 0`:
- Before: env var omitted, n8n applies its default of 10000.
- After: env var set to `0`, n8n disables count-based pruning (per `if (pruneDataMaxCount > 0)` in `execution.repository.ts`).

Anyone on the chart default or any positive override sees no change.

## Test plan

- [x] `helm template` with default values → `EXECUTIONS_DATA_PRUNE_MAX_COUNT="10000"`
- [x] `helm template --set executions.pruning.maxCount=0` → `EXECUTIONS_DATA_PRUNE_MAX_COUNT="0"`
- [x] `helm template --set executions.pruning.maxCount=50000` → `EXECUTIONS_DATA_PRUNE_MAX_COUNT="50000"`
- [x] End-to-end `helm install` against OrbStack with `maxCount=0`: confirmed env var present on both `main` and `worker` deployment specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)