### PR TITLE
feat(chart): add global chart metadata support

### DIFF
--- a/charts/n8n/examples/README.md
+++ b/charts/n8n/examples/README.md
@@ -6,7 +6,7 @@ This directory contains common configuration examples for different deployment s
 
 ### Community Examples (No License Required)
 - **[standalone.yaml](./standalone.yaml)** - Single pod with SQLite, no external dependencies
-- **[minimal.yaml](./minimal.yaml)** - Single main pod with external PostgreSQL and Redis
+- **[minimal.yaml](./minimal.yaml)** - Single main pod with external PostgreSQL and Redis; includes `commonLabels` and `commonAnnotations` example
 - **[minimal-with-docker.yaml](./minimal-with-docker.yaml)** - Quick testing with Docker containers
 
 ### Community Examples (Task Runners)

--- a/charts/n8n/examples/minimal.yaml
+++ b/charts/n8n/examples/minimal.yaml
@@ -10,6 +10,15 @@
 #
 # Use this as a starting point for development or testing
 
+# Global metadata applied to all rendered Kubernetes resources
+commonLabels:
+  my-platform.io/team: automation
+  my-platform.io/cost-centre: PE24
+
+commonAnnotations:
+  secret.reloader.stakater.com/auto: "true"
+  my-platform.io/contact: team@example.com
+
 # Basic deployment settings
 queueMode:
   enabled: true

--- a/charts/n8n/templates/_helpers.tpl
+++ b/charts/n8n/templates/_helpers.tpl
@@ -32,6 +32,9 @@ helm.sh/chart: {{ include "n8n.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/charts/n8n/templates/configmap.yaml
+++ b/charts/n8n/templates/configmap.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 data:
   # ----- Shared Configuration (used by all components: main, worker, webhook-processor) -----
   TZ: {{ .Values.config.timezone | quote }}

--- a/charts/n8n/templates/deployment-main.yaml
+++ b/charts/n8n/templates/deployment-main.yaml
@@ -25,15 +25,9 @@ spec:
       app.kubernetes.io/component: main
   template:
     metadata:
+      {{- $podAnns := merge (dict "checksum/config" (include (print $.Template.BasePath "/configmap.yaml") . | sha256sum) "checksum/secret" (include (print $.Template.BasePath "/secrets.yaml") . | sha256sum)) (.Values.podAnnotations | default dict) (.Values.commonAnnotations | default dict) }}
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-        checksum/secret: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
-        {{- with .Values.commonAnnotations }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-        {{- with .Values.podAnnotations }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{- toYaml $podAnns | nindent 8 }}
       labels:
         {{- include "n8n.labels" . | nindent 8 }}
         app.kubernetes.io/component: main

--- a/charts/n8n/templates/deployment-main.yaml
+++ b/charts/n8n/templates/deployment-main.yaml
@@ -7,6 +7,10 @@ metadata:
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
     app.kubernetes.io/component: main
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ ternary .Values.multiMain.replicas .Values.replicaCount .Values.multiMain.enabled }}
   revisionHistoryLimit: 3
@@ -24,6 +28,9 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+        {{- with .Values.commonAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/n8n/templates/deployment-webhook-processor.yaml
+++ b/charts/n8n/templates/deployment-webhook-processor.yaml
@@ -21,15 +21,9 @@ spec:
       app.kubernetes.io/component: webhook-processor
   template:
     metadata:
+      {{- $podAnns := merge (dict "checksum/config" (include (print $.Template.BasePath "/configmap.yaml") . | sha256sum) "checksum/secret" (include (print $.Template.BasePath "/secrets.yaml") . | sha256sum)) (.Values.podAnnotations | default dict) (.Values.commonAnnotations | default dict) }}
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-        checksum/secret: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
-        {{- with .Values.commonAnnotations }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-        {{- with .Values.podAnnotations }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{- toYaml $podAnns | nindent 8 }}
       labels:
         {{- include "n8n.labels" . | nindent 8 }}
         app.kubernetes.io/component: webhook-processor

--- a/charts/n8n/templates/deployment-webhook-processor.yaml
+++ b/charts/n8n/templates/deployment-webhook-processor.yaml
@@ -7,6 +7,10 @@ metadata:
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
     app.kubernetes.io/component: webhook-processor
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.webhookProcessor.replicaCount }}
   revisionHistoryLimit: 3
@@ -20,6 +24,9 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+        {{- with .Values.commonAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/n8n/templates/deployment-worker.yaml
+++ b/charts/n8n/templates/deployment-worker.yaml
@@ -7,6 +7,10 @@ metadata:
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
     app.kubernetes.io/component: worker
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.queueMode.workerReplicaCount }}
   revisionHistoryLimit: 3
@@ -20,6 +24,9 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+        {{- with .Values.commonAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/n8n/templates/deployment-worker.yaml
+++ b/charts/n8n/templates/deployment-worker.yaml
@@ -21,15 +21,9 @@ spec:
       app.kubernetes.io/component: worker
   template:
     metadata:
+      {{- $podAnns := merge (dict "checksum/config" (include (print $.Template.BasePath "/configmap.yaml") . | sha256sum) "checksum/secret" (include (print $.Template.BasePath "/secrets.yaml") . | sha256sum)) (.Values.podAnnotations | default dict) (.Values.commonAnnotations | default dict) }}
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-        checksum/secret: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
-        {{- with .Values.commonAnnotations }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-        {{- with .Values.podAnnotations }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{- toYaml $podAnns | nindent 8 }}
       labels:
         {{- include "n8n.labels" . | nindent 8 }}
         app.kubernetes.io/component: worker

--- a/charts/n8n/templates/hpa-main.yaml
+++ b/charts/n8n/templates/hpa-main.yaml
@@ -7,6 +7,10 @@ metadata:
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
     app.kubernetes.io/component: main
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/n8n/templates/hpa-webhook-processor.yaml
+++ b/charts/n8n/templates/hpa-webhook-processor.yaml
@@ -7,6 +7,10 @@ metadata:
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
     app.kubernetes.io/component: webhook-processor
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/n8n/templates/hpa-worker.yaml
+++ b/charts/n8n/templates/hpa-worker.yaml
@@ -7,6 +7,10 @@ metadata:
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
     app.kubernetes.io/component: worker
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/n8n/templates/ingress-webhook.yaml
+++ b/charts/n8n/templates/ingress-webhook.yaml
@@ -7,14 +7,10 @@ metadata:
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
     app.kubernetes.io/component: webhook-processor
-  {{- if or .Values.commonAnnotations (.Values.ingress.webhookProcessor).annotations }}
+  {{- $merged := merge (deepCopy ((.Values.ingress.webhookProcessor).annotations | default dict)) (.Values.commonAnnotations | default dict) }}
+  {{- with $merged }}
   annotations:
-    {{- with .Values.commonAnnotations }}
     {{- toYaml . | nindent 4 }}
-    {{- end }}
-    {{- with (.Values.ingress.webhookProcessor).annotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
   {{- end }}
 spec:
   {{- with (.Values.ingress.webhookProcessor).className }}

--- a/charts/n8n/templates/ingress-webhook.yaml
+++ b/charts/n8n/templates/ingress-webhook.yaml
@@ -7,9 +7,14 @@ metadata:
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
     app.kubernetes.io/component: webhook-processor
-  {{- with (.Values.ingress.webhookProcessor).annotations }}
+  {{- if or .Values.commonAnnotations (.Values.ingress.webhookProcessor).annotations }}
   annotations:
+    {{- with .Values.commonAnnotations }}
     {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with (.Values.ingress.webhookProcessor).annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- end }}
 spec:
   {{- with (.Values.ingress.webhookProcessor).className }}

--- a/charts/n8n/templates/ingress.yaml
+++ b/charts/n8n/templates/ingress.yaml
@@ -6,11 +6,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
+  {{- $merged := merge (deepCopy (.Values.ingress.annotations | default dict)) (.Values.commonAnnotations | default dict) }}
+  {{- if or $merged (and .Values.ingress.sticky.enabled (or (eq .Values.ingress.className "nginx") (hasKey (default dict .Values.ingress.annotations) "kubernetes.io/ingress.class"))) }}
   annotations:
-    {{- with .Values.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    {{- with .Values.ingress.annotations }}
+    {{- with $merged }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- if and .Values.ingress.sticky.enabled (or (eq .Values.ingress.className "nginx") (hasKey (default dict .Values.ingress.annotations) "kubernetes.io/ingress.class")) }}
@@ -19,6 +18,7 @@ metadata:
     nginx.ingress.kubernetes.io/session-cookie-expires: {{ .Values.ingress.sticky.cookieExpires | quote }}
     nginx.ingress.kubernetes.io/session-cookie-max-age: {{ .Values.ingress.sticky.cookieMaxAge | quote }}
     {{- end }}
+  {{- end }}
 spec:
   {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className }}

--- a/charts/n8n/templates/ingress.yaml
+++ b/charts/n8n/templates/ingress.yaml
@@ -4,8 +4,15 @@ kind: Ingress
 metadata:
   name: {{ include "n8n.fullname" . }}-main
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "n8n.labels" . | nindent 4 }}
   annotations:
-    {{- with .Values.ingress.annotations }}{{ toYaml . | nindent 4 }}{{- end }}
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     {{- if and .Values.ingress.sticky.enabled (or (eq .Values.ingress.className "nginx") (hasKey (default dict .Values.ingress.annotations) "kubernetes.io/ingress.class")) }}
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/session-cookie-name: {{ .Values.ingress.sticky.cookieName | quote }}

--- a/charts/n8n/templates/networkpolicy.yaml
+++ b/charts/n8n/templates/networkpolicy.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   podSelector:
     matchLabels:

--- a/charts/n8n/templates/pdb.yaml
+++ b/charts/n8n/templates/pdb.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   minAvailable: {{ .Values.pdb.minAvailable }}
   selector:

--- a/charts/n8n/templates/pvc.yaml
+++ b/charts/n8n/templates/pvc.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   accessModes: {{ toYaml .Values.persistence.accessModes | nindent 2 }}
   resources:

--- a/charts/n8n/templates/role.yaml
+++ b/charts/n8n/templates/role.yaml
@@ -4,6 +4,12 @@ kind: Role
 metadata:
   name: {{ include "n8n.fullname" . }}
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "n8n.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]

--- a/charts/n8n/templates/rolebinding.yaml
+++ b/charts/n8n/templates/rolebinding.yaml
@@ -4,6 +4,12 @@ kind: RoleBinding
 metadata:
   name: {{ include "n8n.fullname" . }}
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "n8n.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/n8n/templates/scaledobject-webhook-processor.yaml
+++ b/charts/n8n/templates/scaledobject-webhook-processor.yaml
@@ -7,6 +7,10 @@ metadata:
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
     app.kubernetes.io/component: webhook-processor
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   scaleTargetRef:
     name: {{ include "n8n.fullname" . }}-webhook-processor

--- a/charts/n8n/templates/scaledobject-worker.yaml
+++ b/charts/n8n/templates/scaledobject-worker.yaml
@@ -7,6 +7,10 @@ metadata:
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
     app.kubernetes.io/component: worker
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   scaleTargetRef:
     name: {{ include "n8n.fullname" . }}-worker

--- a/charts/n8n/templates/secret-task-runners.yaml
+++ b/charts/n8n/templates/secret-task-runners.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 type: Opaque
 data:
   {{- if .Values.taskRunners.authToken.value }}

--- a/charts/n8n/templates/secrets.yaml
+++ b/charts/n8n/templates/secrets.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 type: Opaque
 stringData:
 {{- range $k, $v := .Values.secretRefs.env }}

--- a/charts/n8n/templates/service-main.yaml
+++ b/charts/n8n/templates/service-main.yaml
@@ -5,15 +5,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
-  {{- $merged := merge (deepCopy (.Values.service.main.annotations | default dict)) (.Values.service.annotations | default dict) }}
-  {{- if or .Values.commonAnnotations $merged }}
+  {{- $merged := merge (deepCopy (.Values.service.main.annotations | default dict)) (.Values.service.annotations | default dict) (.Values.commonAnnotations | default dict) }}
+  {{- with $merged }}
   annotations:
-    {{- with .Values.commonAnnotations }}
     {{- toYaml . | nindent 4 }}
-    {{- end }}
-    {{- with $merged }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
   {{- end }}
 spec:
   type: {{ .Values.service.type }}

--- a/charts/n8n/templates/service-main.yaml
+++ b/charts/n8n/templates/service-main.yaml
@@ -6,9 +6,14 @@ metadata:
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
   {{- $merged := merge (deepCopy (.Values.service.main.annotations | default dict)) (.Values.service.annotations | default dict) }}
-  {{- with $merged }}
+  {{- if or .Values.commonAnnotations $merged }}
   annotations:
+    {{- with .Values.commonAnnotations }}
     {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with $merged }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- end }}
 spec:
   type: {{ .Values.service.type }}

--- a/charts/n8n/templates/service-webhook-processor.yaml
+++ b/charts/n8n/templates/service-webhook-processor.yaml
@@ -7,15 +7,10 @@ metadata:
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
     app.kubernetes.io/component: webhook-processor
-  {{- $merged := merge (deepCopy (.Values.service.webhookProcessor.annotations | default dict)) (.Values.service.annotations | default dict) }}
-  {{- if or .Values.commonAnnotations $merged }}
+  {{- $merged := merge (deepCopy (.Values.service.webhookProcessor.annotations | default dict)) (.Values.service.annotations | default dict) (.Values.commonAnnotations | default dict) }}
+  {{- with $merged }}
   annotations:
-    {{- with .Values.commonAnnotations }}
     {{- toYaml . | nindent 4 }}
-    {{- end }}
-    {{- with $merged }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
   {{- end }}
 spec:
   type: {{ .Values.service.type }}

--- a/charts/n8n/templates/service-webhook-processor.yaml
+++ b/charts/n8n/templates/service-webhook-processor.yaml
@@ -8,9 +8,14 @@ metadata:
     {{- include "n8n.labels" . | nindent 4 }}
     app.kubernetes.io/component: webhook-processor
   {{- $merged := merge (deepCopy (.Values.service.webhookProcessor.annotations | default dict)) (.Values.service.annotations | default dict) }}
-  {{- with $merged }}
+  {{- if or .Values.commonAnnotations $merged }}
   annotations:
+    {{- with .Values.commonAnnotations }}
     {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with $merged }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- end }}
 spec:
   type: {{ .Values.service.type }}

--- a/charts/n8n/templates/serviceaccount.yaml
+++ b/charts/n8n/templates/serviceaccount.yaml
@@ -6,14 +6,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
+  {{- $saAnns := dict }}
+  {{- if and .Values.s3.enabled .Values.s3.auth.autoDetect .Values.serviceAccount.awsRoleArn }}
+  {{- $_ := set $saAnns "eks.amazonaws.com/role-arn" .Values.serviceAccount.awsRoleArn }}
+  {{- end }}
+  {{- $merged := merge (deepCopy (.Values.serviceAccount.annotations | default dict)) $saAnns (.Values.commonAnnotations | default dict) }}
+  {{- with $merged }}
   annotations:
-    {{- with .Values.commonAnnotations }}
     {{- toYaml . | nindent 4 }}
-    {{- end }}
-    {{- if and .Values.s3.enabled .Values.s3.auth.autoDetect .Values.serviceAccount.awsRoleArn }}
-    eks.amazonaws.com/role-arn: {{ .Values.serviceAccount.awsRoleArn }}
-    {{- end }}
-    {{- with .Values.serviceAccount.annotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/n8n/templates/serviceaccount.yaml
+++ b/charts/n8n/templates/serviceaccount.yaml
@@ -4,9 +4,16 @@ kind: ServiceAccount
 metadata:
   name: {{ include "n8n.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "n8n.labels" . | nindent 4 }}
   annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     {{- if and .Values.s3.enabled .Values.s3.auth.autoDetect .Values.serviceAccount.awsRoleArn }}
     eks.amazonaws.com/role-arn: {{ .Values.serviceAccount.awsRoleArn }}
     {{- end }}
-    {{- with .Values.serviceAccount.annotations }}{{ toYaml . | nindent 4 }}{{- end }}
+    {{- with .Values.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/charts/n8n/templates/tests/test-connection.yaml
+++ b/charts/n8n/templates/tests/test-connection.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
   annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:

--- a/charts/n8n/values.schema.json
+++ b/charts/n8n/values.schema.json
@@ -16,6 +16,16 @@
       "required": ["repository", "tag"]
     },
     "replicaCount": { "type": "integer", "minimum": 1 },
+    "commonLabels": {
+      "type": "object",
+      "additionalProperties": { "type": "string" },
+      "default": {}
+    },
+    "commonAnnotations": {
+      "type": "object",
+      "additionalProperties": { "type": "string" },
+      "default": {}
+    },
     "multiMain": {
       "type": "object",
       "properties": {

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -8,6 +8,22 @@ image:
 nameOverride: ""
 fullnameOverride: ""
 
+# ----- Common labels and annotations -----
+# Applied to all Kubernetes resources in this chart.
+# Useful for governance requirements such as cost allocation tags,
+# team ownership labels, and tooling annotations (e.g., Stakater Reloader).
+commonLabels: {}
+# Example:
+# commonLabels:
+#   my-platform.io/team: cloud-engineering
+#   my-platform.io/cost-centre: PE24
+
+commonAnnotations: {}
+# Example:
+# commonAnnotations:
+#   secret.reloader.stakater.com/auto: "true"
+#   my-platform.io/contact: team@example.com
+
 # ----- Queue mode -----
 # Two deployment modes are supported:
 #   1. Queue mode (enabled: true, default) — main + workers + optional webhook processors.


### PR DESCRIPTION
# Pull Request

## Description
Adds chart-wide support for `commonLabels` and `commonAnnotations` so users can apply consistent metadata across rendered resources from a single values entry.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Example/configuration update
- [ ] CI/CD improvements

## Related Issues
Closes #120

## Changes Made
- Added `commonLabels` and `commonAnnotations` values and schema definitions.
- Applied common labels/annotations across core chart resources (Deployments, Services, Ingresses, HPAs/ScaledObjects, RBAC, PDB/PVC, ConfigMap/Secrets, etc.).
- Added pod-template annotation support in deployment templates.
- Updated `charts/n8n/examples/minimal.yaml` and examples README to show usage.

## Testing Performed

### Chart Validation
- [x] `helm lint charts/n8n` passes
- [ ] `./scripts/validate-examples.sh` passes
- [x] Template rendering works with all examples

### Deployment Testing (if applicable)
- [x] Tested with minimal configuration
- [x] Tested with production configuration
- [x] Tested upgrade path from previous version
- [x] All pods start successfully
- [x] Application is accessible

### Specific Testing for Changes
Describe any specific testing you performed for your changes:
- Rendered templates with multiple example values files (including production-style example) and verified metadata appears in expected resources.
- Verified pod-level annotations are rendered in all deployment variants (main, worker, webhook-processor).

## Breaking Changes
If this includes breaking changes, describe what they are and provide migration instructions:
- None.

## Documentation Updates
- [ ] Updated Chart.yaml version (if needed)
- [ ] Updated CHANGELOG.md
- [ ] Updated README.md (if needed)
- [x] Updated examples (if needed)
- [ ] Updated CONTRIBUTING.md (if needed)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added examples that demonstrate the changes (if applicable)
- [ ] All new and existing tests pass

## Screenshots (if applicable)
N/A

## Additional Notes
This change is additive and backward-compatible. Existing chart users are unaffected unless they set `commonLabels` and/or `commonAnnotations`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds global metadata to the `n8n` Helm chart via `commonLabels` and `commonAnnotations`, applied across all resources and pod templates. This reduces repetition for governance tags and enables tools like Stakater Reloader.

- **New Features**
  - Added `commonLabels` and `commonAnnotations` to `values.yaml` and `values.schema.json` (default `{}`).
  - Applied `commonLabels` via the shared labels helper so all resources inherit them.
  - Applied `commonAnnotations` to resource metadata and pod templates; merged with resource-specific annotations when present.
  - Updated `examples/minimal.yaml` and examples README with usage.

- **Bug Fixes**
  - Use Helm `merge` for annotation precedence across all templates to ensure resource-specific > common, prevent duplicate keys, and avoid empty annotations blocks.

<sup>Written for commit 32e2166454ecc67b784daaed80fc8148cb0cccd1. Summary will update on new commits. <a href="https://cubic.dev/pr/n8n-io/n8n-hosting/pull/130?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



