### PR TITLE
fix(chart): suppress replicas when hpa is enabled

### DIFF
--- a/charts/n8n/templates/deployment-main.yaml
+++ b/charts/n8n/templates/deployment-main.yaml
@@ -8,7 +8,9 @@ metadata:
     {{- include "n8n.labels" . | nindent 4 }}
     app.kubernetes.io/component: main
 spec:
+  {{- if not .Values.hpa.main.enabled }}
   replicas: {{ ternary .Values.multiMain.replicas .Values.replicaCount .Values.multiMain.enabled }}
+  {{- end }}
   revisionHistoryLimit: 3
   {{- with .Values.strategy }}
   strategy:

--- a/charts/n8n/templates/deployment-webhook-processor.yaml
+++ b/charts/n8n/templates/deployment-webhook-processor.yaml
@@ -8,7 +8,9 @@ metadata:
     {{- include "n8n.labels" . | nindent 4 }}
     app.kubernetes.io/component: webhook-processor
 spec:
+  {{- if not .Values.hpa.webhookProcessor.enabled }}
   replicas: {{ .Values.webhookProcessor.replicaCount }}
+  {{- end }}
   revisionHistoryLimit: 3
   selector:
     matchLabels:

--- a/charts/n8n/templates/deployment-worker.yaml
+++ b/charts/n8n/templates/deployment-worker.yaml
@@ -8,7 +8,9 @@ metadata:
     {{- include "n8n.labels" . | nindent 4 }}
     app.kubernetes.io/component: worker
 spec:
+  {{- if not .Values.hpa.worker.enabled }}
   replicas: {{ .Values.queueMode.workerReplicaCount }}
+  {{- end }}
   revisionHistoryLimit: 3
   selector:
     matchLabels:


### PR DESCRIPTION
# Pull Request

## Description
Fixes replica handling in deployment templates so `spec.replicas` is not rendered when HPA is enabled for that component.

This prevents conflicts between Kubernetes HPA-managed scaling and statically defined replicas in the chart output.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Example/configuration update
- [ ] CI/CD improvements

## Related Issues
Fixes # (issue)
Relates to # (issue)

## Changes Made
- Updated `charts/n8n/templates/deployment-main.yaml` to render `replicas` only when `hpa.main.enabled` is `false`.
- Updated `charts/n8n/templates/deployment-worker.yaml` to render `replicas` only when `hpa.worker.enabled` is `false`.
- Updated `charts/n8n/templates/deployment-webhook-processor.yaml` to render `replicas` only when `hpa.webhookProcessor.enabled` is `false`.

## Testing Performed

### Chart Validation
- [x] `helm lint charts/n8n` passes
- [ ] `./scripts/validate-examples.sh` passes
- [x] Template rendering works with all examples

### Deployment Testing (if applicable)
- [ ] Tested with minimal configuration
- [ ] Tested with production configuration
- [ ] Tested upgrade path from previous version
- [ ] All pods start successfully
- [ ] Application is accessible

### Specific Testing for Changes
Describe any specific testing you performed for your changes:
- Ran `helm lint charts/n8n` successfully.
- Verified the branch only changes the three deployment templates needed for this fix.
- Confirmed the implementation conditionally omits `spec.replicas` when the related HPA flag is enabled.

## Breaking Changes
If this includes breaking changes, describe what they are and provide migration instructions:
- None.

## Documentation Updates
- [ ] Updated Chart.yaml version (if needed)
- [ ] Updated CHANGELOG.md
- [ ] Updated README.md (if needed)
- [ ] Updated examples (if needed)
- [ ] Updated CONTRIBUTING.md (if needed)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added examples that demonstrate the changes (if applicable)
- [ ] All new and existing tests pass

## Screenshots (if applicable)
Add screenshots to help explain your changes.

## Additional Notes
- This PR is intentionally limited to conditional `replicas` rendering for HPA-enabled deployments.
- No schema, values, or documentation changes are included in this branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppress spec.replicas in Helm deployment templates when HPA is enabled, so HPA controls scaling without conflicts. Applies to main, worker, and webhook-processor deployments.

<sup>Written for commit 6ba494257c5e36e78a87bf3228445951e9ade057. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

