### PR TITLE
feat(chart): add node placement per deployment

### DIFF
--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -100,8 +100,35 @@ To use the namespace's default ServiceAccount, set `name: ""`. If you set `creat
 | `hpa.worker.enabled` | HPA for worker pods | `false` |
 | `keda.enabled` | KEDA queue-based autoscaling | `false` |
 | `networkPolicy.enabled` | Network policies | `false` |
+| `nodePlacement` | Component-specific node placement overrides | `{}` |
 
 See [values.yaml](./values.yaml) for the full list of configurable values.
+
+## Node Placement
+
+Set global `nodeSelector`, `tolerations`, and `affinity` values to apply the same placement rules to all n8n pods. To target a specific deployment, set the matching `nodePlacement.main`, `nodePlacement.worker`, or `nodePlacement.webhookProcessor` value. Component-specific values take precedence; empty component values fall back to the global settings.
+
+```yaml
+nodeSelector:
+  kubernetes.io/os: linux
+
+nodePlacement:
+  worker:
+    nodeSelector:
+      workload: workers
+    tolerations:
+      - key: dedicated
+        operator: Equal
+        value: n8n-workers
+        effect: NoSchedule
+  webhookProcessor:
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+```
 
 ## Task Runners
 

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -130,6 +130,10 @@ nodePlacement:
               topologyKey: kubernetes.io/hostname
 ```
 
+> **Note:** When `multiMain.enabled=true`, the chart emits an automatic pod-anti-affinity rule to spread main replicas across nodes. Setting `nodePlacement.main.affinity` replaces that auto rule — include your own pod-anti-affinity term if you still want main replicas spread.
+
+See [`examples/node-placement.yaml`](./examples/node-placement.yaml) for a complete configuration that pins `main` to a stable node pool and lets workers run on an autoscaling pool.
+
 ## Task Runners
 
 Task runners execute user-provided JavaScript and Python code in isolated sidecar containers, separate from the main n8n process. When enabled, each main and worker pod gets a runner sidecar.

--- a/charts/n8n/examples/README.md
+++ b/charts/n8n/examples/README.md
@@ -15,6 +15,9 @@ This directory contains common configuration examples for different deployment s
 ### Community Examples (KEDA Autoscaling)
 - **[keda-autoscaling.yaml](./keda-autoscaling.yaml)** - Redis queue-length worker scaling with KEDA
 
+### Community Examples (Node Placement)
+- **[node-placement.yaml](./node-placement.yaml)** - Pin `main` and webhook-processor to a stable node pool; run workers on an autoscaling pool
+
 ### Enterprise Examples (License Required)
 - **[production-s3.yaml](./production-s3.yaml)** - Production setup with multi-main, webhooks, S3 storage, and autoscaling
 - **[multi-main-queue.yaml](./multi-main-queue.yaml)** - Multi-main and queue mode configuration

--- a/charts/n8n/examples/node-placement.yaml
+++ b/charts/n8n/examples/node-placement.yaml
@@ -1,0 +1,63 @@
+# Per-component node placement
+#
+# This example separates n8n's user-facing pods (main, webhook-processor) from
+# its background workers, so the two groups can be scheduled on different node
+# pools. A common reason to do this is to keep the UI/API on a stable pool
+# while letting workers run on a pool that scales aggressively or rotates nodes
+# (e.g. EKS auto-mode, GKE Autopilot, spot/preemptible pools), without
+# disruptions to the frontend.
+#
+# Assumes nodes are labelled (or tainted) along the lines of:
+#   pool=n8n-frontend  -> stable nodes for main + webhook-processor
+#   pool=n8n-workers   -> autoscaling / cheap nodes for worker pods
+#                         (optionally tainted: dedicated=n8n-workers:NoSchedule)
+
+queueMode:
+  enabled: true
+  workerReplicaCount: 4
+
+webhookProcessor:
+  enabled: true
+  replicaCount: 2
+  disableProductionWebhooksOnMainProcess: true
+
+# Required external services (replace with your own)
+database:
+  type: postgresdb
+  useExternal: true
+  host: "your-postgres-host"
+  port: 5432
+  database: n8n
+  user: n8n
+  passwordSecret:
+    name: "n8n-db-password"
+    key: "password"
+
+redis:
+  enabled: true
+  useExternal: true
+  host: "your-redis-host"
+  port: 6379
+
+secretRefs:
+  existingSecret: "n8n-core-secrets"
+
+# ----- Node placement -----
+# Per-component overrides. Any unset component would fall back to the global
+# `nodeSelector` / `tolerations` / `affinity` keys (not set here).
+nodePlacement:
+  main:
+    nodeSelector:
+      pool: n8n-frontend
+  webhookProcessor:
+    nodeSelector:
+      pool: n8n-frontend
+  worker:
+    nodeSelector:
+      pool: n8n-workers
+    # If the worker pool is tainted, tolerate it here.
+    tolerations:
+      - key: dedicated
+        operator: Equal
+        value: n8n-workers
+        effect: NoSchedule

--- a/charts/n8n/templates/deployment-main.yaml
+++ b/charts/n8n/templates/deployment-main.yaml
@@ -226,13 +226,19 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
 
-      {{- with .Values.nodeSelector }}
-      nodeSelector: {{- toYaml . | nindent 8 }}
+      {{- if .Values.nodePlacement.main.nodeSelector }}
+      nodeSelector: {{- toYaml .Values.nodePlacement.main.nodeSelector | nindent 8 }}
+      {{- else if .Values.nodeSelector }}
+      nodeSelector: {{- toYaml .Values.nodeSelector | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
-      tolerations: {{- toYaml . | nindent 8 }}
+      {{- if .Values.nodePlacement.main.tolerations }}
+      tolerations: {{- toYaml .Values.nodePlacement.main.tolerations | nindent 8 }}
+      {{- else if .Values.tolerations }}
+      tolerations: {{- toYaml .Values.tolerations | nindent 8 }}
       {{- end }}
-      {{- if .Values.affinity }}
+      {{- if .Values.nodePlacement.main.affinity }}
+      affinity: {{- toYaml .Values.nodePlacement.main.affinity | nindent 8 }}
+      {{- else if .Values.affinity }}
       affinity: {{- toYaml .Values.affinity | nindent 8 }}
       {{- else if and .Values.multiMain.enabled (ne .Values.multiMain.antiAffinity.type "none") }}
       affinity:

--- a/charts/n8n/templates/deployment-main.yaml
+++ b/charts/n8n/templates/deployment-main.yaml
@@ -226,18 +226,20 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
 
-      {{- if .Values.nodePlacement.main.nodeSelector }}
-      nodeSelector: {{- toYaml .Values.nodePlacement.main.nodeSelector | nindent 8 }}
+      {{- $nodePlacement := .Values.nodePlacement | default dict }}
+      {{- $componentPlacement := $nodePlacement.main | default dict }}
+      {{- if $componentPlacement.nodeSelector }}
+      nodeSelector: {{- toYaml $componentPlacement.nodeSelector | nindent 8 }}
       {{- else if .Values.nodeSelector }}
       nodeSelector: {{- toYaml .Values.nodeSelector | nindent 8 }}
       {{- end }}
-      {{- if .Values.nodePlacement.main.tolerations }}
-      tolerations: {{- toYaml .Values.nodePlacement.main.tolerations | nindent 8 }}
+      {{- if $componentPlacement.tolerations }}
+      tolerations: {{- toYaml $componentPlacement.tolerations | nindent 8 }}
       {{- else if .Values.tolerations }}
       tolerations: {{- toYaml .Values.tolerations | nindent 8 }}
       {{- end }}
-      {{- if .Values.nodePlacement.main.affinity }}
-      affinity: {{- toYaml .Values.nodePlacement.main.affinity | nindent 8 }}
+      {{- if $componentPlacement.affinity }}
+      affinity: {{- toYaml $componentPlacement.affinity | nindent 8 }}
       {{- else if .Values.affinity }}
       affinity: {{- toYaml .Values.affinity | nindent 8 }}
       {{- else if and .Values.multiMain.enabled (ne .Values.multiMain.antiAffinity.type "none") }}

--- a/charts/n8n/templates/deployment-webhook-processor.yaml
+++ b/charts/n8n/templates/deployment-webhook-processor.yaml
@@ -201,13 +201,19 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
 
-      {{- with .Values.nodeSelector }}
-      nodeSelector: {{- toYaml . | nindent 8 }}
+      {{- if .Values.nodePlacement.webhookProcessor.nodeSelector }}
+      nodeSelector: {{- toYaml .Values.nodePlacement.webhookProcessor.nodeSelector | nindent 8 }}
+      {{- else if .Values.nodeSelector }}
+      nodeSelector: {{- toYaml .Values.nodeSelector | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
-      tolerations: {{- toYaml . | nindent 8 }}
+      {{- if .Values.nodePlacement.webhookProcessor.tolerations }}
+      tolerations: {{- toYaml .Values.nodePlacement.webhookProcessor.tolerations | nindent 8 }}
+      {{- else if .Values.tolerations }}
+      tolerations: {{- toYaml .Values.tolerations | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
-      affinity: {{- toYaml . | nindent 8 }}
+      {{- if .Values.nodePlacement.webhookProcessor.affinity }}
+      affinity: {{- toYaml .Values.nodePlacement.webhookProcessor.affinity | nindent 8 }}
+      {{- else if .Values.affinity }}
+      affinity: {{- toYaml .Values.affinity | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/n8n/templates/deployment-webhook-processor.yaml
+++ b/charts/n8n/templates/deployment-webhook-processor.yaml
@@ -201,18 +201,20 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
 
-      {{- if .Values.nodePlacement.webhookProcessor.nodeSelector }}
-      nodeSelector: {{- toYaml .Values.nodePlacement.webhookProcessor.nodeSelector | nindent 8 }}
+      {{- $nodePlacement := .Values.nodePlacement | default dict }}
+      {{- $componentPlacement := $nodePlacement.webhookProcessor | default dict }}
+      {{- if $componentPlacement.nodeSelector }}
+      nodeSelector: {{- toYaml $componentPlacement.nodeSelector | nindent 8 }}
       {{- else if .Values.nodeSelector }}
       nodeSelector: {{- toYaml .Values.nodeSelector | nindent 8 }}
       {{- end }}
-      {{- if .Values.nodePlacement.webhookProcessor.tolerations }}
-      tolerations: {{- toYaml .Values.nodePlacement.webhookProcessor.tolerations | nindent 8 }}
+      {{- if $componentPlacement.tolerations }}
+      tolerations: {{- toYaml $componentPlacement.tolerations | nindent 8 }}
       {{- else if .Values.tolerations }}
       tolerations: {{- toYaml .Values.tolerations | nindent 8 }}
       {{- end }}
-      {{- if .Values.nodePlacement.webhookProcessor.affinity }}
-      affinity: {{- toYaml .Values.nodePlacement.webhookProcessor.affinity | nindent 8 }}
+      {{- if $componentPlacement.affinity }}
+      affinity: {{- toYaml $componentPlacement.affinity | nindent 8 }}
       {{- else if .Values.affinity }}
       affinity: {{- toYaml .Values.affinity | nindent 8 }}
       {{- end }}

--- a/charts/n8n/templates/deployment-worker.yaml
+++ b/charts/n8n/templates/deployment-worker.yaml
@@ -214,18 +214,20 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
 
-      {{- if .Values.nodePlacement.worker.nodeSelector }}
-      nodeSelector: {{- toYaml .Values.nodePlacement.worker.nodeSelector | nindent 8 }}
+      {{- $nodePlacement := .Values.nodePlacement | default dict }}
+      {{- $componentPlacement := $nodePlacement.worker | default dict }}
+      {{- if $componentPlacement.nodeSelector }}
+      nodeSelector: {{- toYaml $componentPlacement.nodeSelector | nindent 8 }}
       {{- else if .Values.nodeSelector }}
       nodeSelector: {{- toYaml .Values.nodeSelector | nindent 8 }}
       {{- end }}
-      {{- if .Values.nodePlacement.worker.tolerations }}
-      tolerations: {{- toYaml .Values.nodePlacement.worker.tolerations | nindent 8 }}
+      {{- if $componentPlacement.tolerations }}
+      tolerations: {{- toYaml $componentPlacement.tolerations | nindent 8 }}
       {{- else if .Values.tolerations }}
       tolerations: {{- toYaml .Values.tolerations | nindent 8 }}
       {{- end }}
-      {{- if .Values.nodePlacement.worker.affinity }}
-      affinity: {{- toYaml .Values.nodePlacement.worker.affinity | nindent 8 }}
+      {{- if $componentPlacement.affinity }}
+      affinity: {{- toYaml $componentPlacement.affinity | nindent 8 }}
       {{- else if .Values.affinity }}
       affinity: {{- toYaml .Values.affinity | nindent 8 }}
       {{- end }}

--- a/charts/n8n/templates/deployment-worker.yaml
+++ b/charts/n8n/templates/deployment-worker.yaml
@@ -214,13 +214,19 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
 
-      {{- with .Values.nodeSelector }}
-      nodeSelector: {{- toYaml . | nindent 8 }}
+      {{- if .Values.nodePlacement.worker.nodeSelector }}
+      nodeSelector: {{- toYaml .Values.nodePlacement.worker.nodeSelector | nindent 8 }}
+      {{- else if .Values.nodeSelector }}
+      nodeSelector: {{- toYaml .Values.nodeSelector | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
-      tolerations: {{- toYaml . | nindent 8 }}
+      {{- if .Values.nodePlacement.worker.tolerations }}
+      tolerations: {{- toYaml .Values.nodePlacement.worker.tolerations | nindent 8 }}
+      {{- else if .Values.tolerations }}
+      tolerations: {{- toYaml .Values.tolerations | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
-      affinity: {{- toYaml . | nindent 8 }}
+      {{- if .Values.nodePlacement.worker.affinity }}
+      affinity: {{- toYaml .Values.nodePlacement.worker.affinity | nindent 8 }}
+      {{- else if .Values.affinity }}
+      affinity: {{- toYaml .Values.affinity | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/n8n/values.schema.json
+++ b/charts/n8n/values.schema.json
@@ -274,6 +274,45 @@
     },
     "tolerations": { "type": "array" },
     "affinity": { "type": "object" },
+    "nodePlacement": {
+      "type": "object",
+      "description": "Component-specific pod node placement values. Non-empty component values override the global nodeSelector, tolerations, and affinity values.",
+      "properties": {
+        "main": {
+          "type": "object",
+          "properties": {
+            "nodeSelector": {
+              "type": "object",
+              "additionalProperties": { "type": "string" }
+            },
+            "tolerations": { "type": "array" },
+            "affinity": { "type": "object" }
+          }
+        },
+        "worker": {
+          "type": "object",
+          "properties": {
+            "nodeSelector": {
+              "type": "object",
+              "additionalProperties": { "type": "string" }
+            },
+            "tolerations": { "type": "array" },
+            "affinity": { "type": "object" }
+          }
+        },
+        "webhookProcessor": {
+          "type": "object",
+          "properties": {
+            "nodeSelector": {
+              "type": "object",
+              "additionalProperties": { "type": "string" }
+            },
+            "tolerations": { "type": "array" },
+            "affinity": { "type": "object" }
+          }
+        }
+      }
+    },
     "podAnnotations": { "type": "object", "additionalProperties": true },
     "podLabels": { "type": "object", "additionalProperties": true },
     "securityContext": {

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -226,9 +226,26 @@ resources:
       memory: 512Mi
 
 # ----- Node placement -----
+# Global defaults used by all n8n pods unless overridden in nodePlacement below.
 nodeSelector: {}
 tolerations: []
 affinity: {}
+
+# Component-specific node placement. When a component value is empty, the chart
+# falls back to the global nodeSelector, tolerations, or affinity value above.
+nodePlacement:
+  main:
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+  worker:
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+  webhookProcessor:
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
 
 # ----- Security -----
 # Note: readOnlyRootFilesystem is intentionally not set. n8n writes to

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -226,26 +226,29 @@ resources:
       memory: 512Mi
 
 # ----- Node placement -----
-# Global defaults used by all n8n pods unless overridden in nodePlacement below.
+# Global defaults applied to every n8n pod (main, worker, webhook-processor)
+# unless overridden in nodePlacement below.
 nodeSelector: {}
 tolerations: []
 affinity: {}
 
-# Component-specific node placement. When a component value is empty, the chart
-# falls back to the global nodeSelector, tolerations, or affinity value above.
-nodePlacement:
-  main:
-    nodeSelector: {}
-    tolerations: []
-    affinity: {}
-  worker:
-    nodeSelector: {}
-    tolerations: []
-    affinity: {}
-  webhookProcessor:
-    nodeSelector: {}
-    tolerations: []
-    affinity: {}
+# Per-component overrides. Any value set here takes precedence over the global
+# nodeSelector/tolerations/affinity above for that component only; unset
+# components fall back to the globals.
+nodePlacement: {}
+# Example:
+# nodePlacement:
+#   main:
+#     nodeSelector:
+#       workload: n8n-frontend
+#   worker:
+#     nodeSelector:
+#       workload: n8n-workers
+#     tolerations:
+#       - key: dedicated
+#         operator: Equal
+#         value: n8n-workers
+#         effect: NoSchedule
 
 # ----- Security -----
 # Note: readOnlyRootFilesystem is intentionally not set. n8n writes to


### PR DESCRIPTION
# Pull Request

## Description
Adds component-specific node placement support to the n8n Helm chart, allowing `main`, `worker`, and `webhookProcessor` deployments to define their own `nodeSelector`, `tolerations`, and `affinity` while preserving the existing global defaults as fallbacks.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Example/configuration update
- [ ] CI/CD improvements

## Related Issues
Fixes # N/A
Relates to # N/A

## Changes Made
- Added the ability to define node placements per deployment instead of forcing the global configuration

## Testing Performed
- Tested the chart with and without this new configuration

### Chart Validation
- [x] `helm lint charts/n8n` passes
- [ ] `./scripts/validate-examples.sh` passes
- [x] Template rendering works with all examples

### Deployment Testing (if applicable)
- [x] Tested with minimal configuration
- [x] Tested with production configuration
- [ ] Tested upgrade path from previous version
- [x] All pods start successfully
- [x] Application is accessible

### Specific Testing for Changes
Describe any specific testing you performed for your changes:
- Rendered the chart without `nodePlacement` overrides to confirm existing global `nodeSelector`, `tolerations`, and `affinity` behavior is preserved.
- Rendered the chart with component-specific `nodePlacement` overrides for `main`, `worker`, and `webhookProcessor` to confirm each deployment uses its own scheduling configuration.

## Breaking Changes
If this includes breaking changes, describe what they are and provide migration instructions:
- None. Existing global `nodeSelector`, `tolerations`, and `affinity` values continue to work as fallbacks when component-specific values are not set.

## Documentation Updates
- [ ] Updated Chart.yaml version (if needed)
- [ ] Updated CHANGELOG.md
- [x] Updated README.md (if needed)
- [ ] Updated examples (if needed)
- [ ] Updated CONTRIBUTING.md (if needed)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added examples that demonstrate the changes (if applicable)
- [x] All new and existing tests pass

## Screenshots (if applicable)
Not applicable.

## Additional Notes
This change is backward compatible because component-specific placement values only take precedence when configured; otherwise the chart continues to use the existing global placement settings.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-deployment node placement to the `n8n` Helm chart so you can set scheduling rules per component instead of one global setting. Adds an example and clarifies how `multiMain` anti-affinity behaves when `nodePlacement.main.affinity` is set.

- **New Features**
  - Added `nodePlacement.main`, `nodePlacement.worker`, and `nodePlacement.webhookProcessor` with `nodeSelector`, `tolerations`, and `affinity`.
  - Deployments prefer component overrides and fall back to global `nodeSelector`, `tolerations`, and `affinity`; updated `values.schema.json`, set default `nodePlacement: {}` in `values.yaml` with a commented example, added `examples/node-placement.yaml`, and documented that `nodePlacement.main.affinity` replaces the auto anti-affinity when `multiMain.enabled=true`.

- **Bug Fixes**
  - Protected templates against null or misconfigured `nodePlacement` values using `default dict` and explicit checks to prevent rendering errors.

<sup>Written for commit 190fce4e4c1b2f127b694ae77b46b50812b3fcc3. Summary will update on new commits. <a href="https://cubic.dev/pr/n8n-io/n8n-hosting/pull/135?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


