### PR TITLE
feat(chart): add extraInitContainers, dnsPolicy/dnsConfig, and serviceAccount.automountServiceAccountToken

### DIFF
--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -101,6 +101,9 @@ To use the namespace's default ServiceAccount, set `name: ""`. If you set `creat
 | `keda.enabled` | KEDA queue-based autoscaling | `false` |
 | `networkPolicy.enabled` | Network policies | `false` |
 | `nodePlacement` | Component-specific node placement overrides | `{}` |
+| `extraInitContainers` | Init containers (incl. native sidecars) on all n8n pods | `[]` |
+| `dnsPolicy` / `dnsConfig` | Pod DNS policy + configuration for all n8n pods | `""` / `{}` |
+| `serviceAccount.automountServiceAccountToken` | Pod-level toggle for ServiceAccount token automount | unset |
 
 See [values.yaml](./values.yaml) for the full list of configurable values.
 

--- a/charts/n8n/templates/deployment-main.yaml
+++ b/charts/n8n/templates/deployment-main.yaml
@@ -34,6 +34,9 @@ spec:
       {{- with include "n8n.serviceAccountName" . }}
       serviceAccountName: {{ . }}
       {{- end }}
+      {{- if hasKey .Values.serviceAccount "automountServiceAccountToken" }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      {{- end }}
 
       {{- if .Values.securityContext.enabled }}
       securityContext:
@@ -45,8 +48,21 @@ spec:
           type: RuntimeDefault
       {{- end }}
 
+      {{- with .Values.dnsPolicy }}
+      dnsPolicy: {{ . }}
+      {{- end }}
+      {{- with .Values.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
       {{- with .Values.lifecycle.main.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ . }}
+      {{- end }}
+
+      {{- with .Values.extraInitContainers }}
+      initContainers:
+        {{- tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
 
       containers:

--- a/charts/n8n/templates/deployment-webhook-processor.yaml
+++ b/charts/n8n/templates/deployment-webhook-processor.yaml
@@ -30,6 +30,9 @@ spec:
       {{- with include "n8n.serviceAccountName" . }}
       serviceAccountName: {{ . }}
       {{- end }}
+      {{- if hasKey .Values.serviceAccount "automountServiceAccountToken" }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      {{- end }}
 
       {{- if .Values.securityContext.enabled }}
       securityContext:
@@ -41,8 +44,21 @@ spec:
           type: RuntimeDefault
       {{- end }}
 
+      {{- with .Values.dnsPolicy }}
+      dnsPolicy: {{ . }}
+      {{- end }}
+      {{- with .Values.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
       {{- with .Values.lifecycle.webhookProcessor.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ . }}
+      {{- end }}
+
+      {{- with .Values.extraInitContainers }}
+      initContainers:
+        {{- tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
 
       containers:

--- a/charts/n8n/templates/deployment-worker.yaml
+++ b/charts/n8n/templates/deployment-worker.yaml
@@ -30,6 +30,9 @@ spec:
       {{- with include "n8n.serviceAccountName" . }}
       serviceAccountName: {{ . }}
       {{- end }}
+      {{- if hasKey .Values.serviceAccount "automountServiceAccountToken" }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      {{- end }}
 
       {{- if .Values.securityContext.enabled }}
       securityContext:
@@ -41,8 +44,21 @@ spec:
           type: RuntimeDefault
       {{- end }}
 
+      {{- with .Values.dnsPolicy }}
+      dnsPolicy: {{ . }}
+      {{- end }}
+      {{- with .Values.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
       {{- with .Values.lifecycle.worker.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ . }}
+      {{- end }}
+
+      {{- with .Values.extraInitContainers }}
+      initContainers:
+        {{- tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
 
       containers:

--- a/charts/n8n/values.schema.json
+++ b/charts/n8n/values.schema.json
@@ -329,8 +329,23 @@
       "properties": {
         "create": { "type": "boolean" },
         "name": { "type": "string" },
-        "annotations": { "type": "object", "additionalProperties": true }
+        "annotations": { "type": "object", "additionalProperties": true },
+        "automountServiceAccountToken": { "type": ["boolean", "null"] }
       }
+    },
+    "extraInitContainers": {
+      "type": "array",
+      "description": "Additional init containers prepended to main, worker, and webhook-processor pods. Entries with restartPolicy: Always are treated as K8s 1.29+ native sidecars.",
+      "items": { "type": "object" }
+    },
+    "dnsPolicy": {
+      "type": "string",
+      "description": "Pod DNS policy applied to main, worker, and webhook-processor pods. Leave empty to use the cluster default."
+    },
+    "dnsConfig": {
+      "type": "object",
+      "description": "Pod DNS configuration applied to main, worker, and webhook-processor pods.",
+      "additionalProperties": true
     },
     "rbac": {
       "type": "object",

--- a/charts/n8n/values.schema.json
+++ b/charts/n8n/values.schema.json
@@ -330,7 +330,7 @@
         "create": { "type": "boolean" },
         "name": { "type": "string" },
         "annotations": { "type": "object", "additionalProperties": true },
-        "automountServiceAccountToken": { "type": ["boolean", "null"] }
+        "automountServiceAccountToken": { "type": "boolean" }
       }
     },
     "extraInitContainers": {

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -201,6 +201,37 @@ extraVolumeMounts: []
 #     mountPath: /app/config
 #     readOnly: true
 
+# ----- Extra init containers -----
+# Prepended to main, worker, and webhook-processor pods. Supports the K8s 1.29+
+# native sidecar pattern by setting `restartPolicy: Always` on an entry —
+# useful for sidecars that must start before the n8n container (e.g. a local
+# DNS resolver that the main container resolves against via dnsConfig).
+# Values are passed through Helm tpl (e.g. `{{ .Release.Name }}`).
+extraInitContainers: []
+# Examples:
+# extraInitContainers:
+#   - name: dns-sidecar
+#     restartPolicy: Always   # <-- native sidecar (requires K8s >= 1.29)
+#     image: my-dns-resolver:1.0.0
+#     startupProbe:
+#       tcpSocket:
+#         port: 53
+#       periodSeconds: 1
+#       failureThreshold: 30
+
+# ----- Pod DNS configuration -----
+# When set, applied to main, worker, and webhook-processor pod specs. Useful
+# for routing DNS through a sidecar resolver (set `dnsPolicy: None` and point
+# `dnsConfig.nameservers` at `127.0.0.1`) or overriding cluster DNS search.
+# See https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
+dnsPolicy: ""
+# Example: dnsPolicy: None
+dnsConfig: {}
+# Example:
+# dnsConfig:
+#   nameservers:
+#     - 127.0.0.1
+
 # ----- Resources -----
 resources:
   main:
@@ -291,6 +322,12 @@ serviceAccount:
   awsRoleArn: ""
   # Additional annotations for the service account
   annotations: {}
+  # Whether the projected ServiceAccount token is mounted into n8n pods.
+  # Omit for the Kubernetes default (true). Set to false to remove the token
+  # from each pod's /var/run/secrets/kubernetes.io/serviceaccount path — n8n
+  # workloads that don't call the Kubernetes API don't need it. Applied at
+  # the pod-spec level so it works regardless of serviceAccount.create.
+  # automountServiceAccountToken: false
 
 networkPolicy:
   enabled: false

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -206,7 +206,9 @@ extraVolumeMounts: []
 # native sidecar pattern by setting `restartPolicy: Always` on an entry —
 # useful for sidecars that must start before the n8n container (e.g. a local
 # DNS resolver that the main container resolves against via dnsConfig).
-# Values are passed through Helm tpl (e.g. `{{ .Release.Name }}`).
+# Values are passed through Helm tpl (e.g. `{{ .Release.Name }}`), so any
+# literal `{{` in a container's args/env/command must be escaped as
+# `{{ "{{" }}` to avoid being parsed as a template directive.
 extraInitContainers: []
 # Examples:
 # extraInitContainers:


### PR DESCRIPTION
## Summary

Three pod-spec extension points, all applied to **main**, **worker**, and **webhook-processor** deployments via the chart's existing global-value pattern (mirroring `extraVolumes` / `extraVolumeMounts` and the `extraContainers` proposal in #138):

1. **`extraInitContainers`** — list of init containers prepended to each pod spec. Supports both classic init containers and the K8s 1.29+ native-sidecar pattern (entries with `restartPolicy: Always`). List entries are passed through Helm `tpl`, so `{{ .Release.Name }}` and other template variables can be referenced in string fields.
2. **`dnsPolicy`** + **`dnsConfig`** — pod-level DNS policy and configuration, mapping directly to the Kubernetes [PodSpec fields](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/). Useful for routing DNS through a sidecar resolver, overriding search domains, or tuning `ndots`.
3. **`serviceAccount.automountServiceAccountToken`** — pod-spec toggle for the ServiceAccount token automount. Defaults to unset (preserves the Kubernetes default of mounting the token). Set to `false` to remove the projected token from `/var/run/secrets/kubernetes.io/serviceaccount` on workloads that don't talk to the Kubernetes API — a small but real attack-surface reduction.

## Why each one

Each of these is the kind of pod-spec field that doesn't fit cleanly under an existing chart abstraction, and is currently only reachable by post-rendering with a Kustomize patch. Surfacing them as first-class values lets users adopt patterns that the chart's current scope doesn't cover:

- **`extraInitContainers`** — running a DNS-filtering sidecar, a local proxy, a credential rotator, a "wait for migrations" gate, or anything else that benefits from native-sidecar `restartPolicy: Always` semantics. Complements the existing volumes/mounts surfaces and the proposed `extraContainers` (#138).
- **`dnsPolicy` / `dnsConfig`** — most non-trivial deployments eventually need to override the default cluster DNS for one reason or another (egress filtering, custom search domain, an upstream that doesn't tolerate `ndots: 5`).
- **`automountServiceAccountToken`** — Pod Security Standards `restricted` profile + general hardening guidance both recommend disabling SA token automount on workloads that don't need API access. n8n itself doesn't call the Kubernetes API.

## Design notes

- All three follow the chart's established **global-value, render-into-all-three-deployments** convention (`extraVolumes`/`extraVolumeMounts` precedent). No per-component variants; if a future need arises, they can be added without breaking existing users.
- `extraInitContainers` uses `tpl (toYaml .)` to keep parity with the `extraContainers` proposal in #138 and to make the feature useful for users templating values from `.Release.Name` etc.
- `automountServiceAccountToken` is implemented at the **pod-spec level** (not on the `ServiceAccount` object) so it works whether the chart creates the SA or `serviceAccount.create: false`. The template uses `hasKey` so an explicit `false` is rendered (Helm's `with` treats `false` as falsy, which would silently drop the setting — easy to miss).
- All three are opt-in, defaults preserve existing behaviour. No values changed for current users.

## Files changed

- `charts/n8n/values.yaml` — three new sections with documentation + commented examples
- `charts/n8n/values.schema.json` — JSON schema entries for the new fields
- `charts/n8n/templates/deployment-main.yaml` — render points
- `charts/n8n/templates/deployment-worker.yaml` — render points
- `charts/n8n/templates/deployment-webhook-processor.yaml` — render points
- `charts/n8n/README.md` — values-table rows + a short section per feature

## Test plan

- [x] `helm lint charts/n8n` clean
- [x] `helm template` renders against all 7 existing example values files (`minimal`, `minimal-with-docker`, `standalone`, `multi-main-queue`, `task-runners`, `keda-autoscaling`, `production-s3`) — no diff in their output
- [x] Verified the three render points fire in main + worker + webhook-processor when the values are set
- [x] Confirmed `serviceAccount.automountServiceAccountToken: false` is rendered (and not swallowed by Helm's falsy-`with` behaviour)
- [ ] CI lint + template-validation (will run on PR)
- [ ] Add `test-install` label if a kind-cluster smoke pass is wanted on top of the existing template validation

## Related

- #138 (`feat(chart): add extraContainers for arbitrary sidecar injection`) — same pattern for regular sidecars. This PR's `extraInitContainers` uses an identical implementation shape, so the two compose naturally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds pod-spec extension points to the `n8n` Helm chart to enable init/native sidecars, custom DNS, and ServiceAccount token hardening across `main`, `worker`, and `webhook-processor` pods. Defaults are unchanged; no migration needed.

- **New Features**
  - `extraInitContainers`: Add init containers to all pods; supports native sidecars (`restartPolicy: Always`). Rendered with Helm `tpl`.
  - `dnsPolicy` / `dnsConfig`: Set pod DNS policy and config on all `n8n` pods.
  - `serviceAccount.automountServiceAccountToken`: Pod-level toggle to disable the projected token. Works whether the chart creates the SA or not.

- **Refactors**
  - Tightened schema to disallow `null` for `serviceAccount.automountServiceAccountToken` (avoids empty bool when using `hasKey`).
  - Documented `tpl` pass-through and how to escape `{{` in `values.yaml`.

<sup>Written for commit cd595087b980e0bc4b60b4d636e7a7b8dd4820bc. Summary will update on new commits. <a href="https://cubic.dev/pr/n8n-io/n8n-hosting/pull/139?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

