### PR TITLE
fix: default readiness probe to /healthz/readiness

### DIFF
--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -361,7 +361,10 @@ probes:
     failureThreshold: 6
   readiness:
     enabled: true
-    path: /healthz
+    # -- HTTP path used for the readiness probe.
+    # Use /healthz/readiness for a more accurate ready check (checks DB + queue connectivity).
+    # Use /healthz if you need the simpler liveness-style check for readiness as well.
+    path: /healthz/readiness # <-- this is the only line that changes
     initialDelaySeconds: 10
     periodSeconds: 10
     timeoutSeconds: 3

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -361,10 +361,7 @@ probes:
     failureThreshold: 6
   readiness:
     enabled: true
-    # -- HTTP path used for the readiness probe.
-    # Use /healthz/readiness for a more accurate ready check (checks DB + queue connectivity).
-    # Use /healthz if you need the simpler liveness-style check for readiness as well.
-    path: /healthz/readiness # <-- this is the only line that changes
+    path: /healthz/readiness
     initialDelaySeconds: 10
     periodSeconds: 10
     timeoutSeconds: 3


### PR DESCRIPTION
## Description
Changes the default `probes.readiness.path` in `values.yaml` from `/healthz` 
to `/healthz/readiness`.

## Why
- `/healthz` only checks that the n8n process is running (process-alive check)
- `/healthz/readiness` checks that n8n is actually ready to serve traffic — 
  it verifies DB connectivity and (in queue mode) Redis connectivity
- Using `/healthz` for readiness means pods are marked ready before they can 
  actually handle requests, causing errors during startup/rolling updates

## Backwards compatibility
The path is fully configurable. Users who prefer the old behaviour can set:
```yaml
probes:
  readiness:
    path: /healthz
```
## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [X] Example/configuration update
- [ ] CI/CD improvements

## Changes Made
Just the value of the readiness path at the values.yaml to check the DB at the readiness checks. 


