### PR TITLE
fix(chart): inject N8N_EDITOR_BASE_URL into containers

### DIFF
--- a/charts/n8n/templates/_configmap-env.tpl
+++ b/charts/n8n/templates/_configmap-env.tpl
@@ -218,6 +218,13 @@ Environment variables from ConfigMap for main pods only
       key: N8N_WEBHOOK_TIMEOUT
 {{- end }}
 {{- end }}
+{{- if or (and .Values.ingress .Values.ingress.enabled (gt (len .Values.ingress.hosts) 0)) (and .Values.webhook.url (hasPrefix "http" (.Values.webhook.url | toString))) }}
+- name: N8N_EDITOR_BASE_URL
+  valueFrom:
+    configMapKeyRef:
+      name: {{ include "n8n.fullname" . }}
+      key: N8N_EDITOR_BASE_URL
+{{- end }}
 {{- if and .Values.multiMain.enabled .Values.license.enabled }}
 - name: N8N_MULTI_MAIN_SETUP_ENABLED
   valueFrom:
@@ -268,6 +275,13 @@ Environment variables from ConfigMap for webhook processor pods (similar to main
       key: N8N_WEBHOOK_TIMEOUT
 {{- end }}
 {{- end }}
+{{- if or (and .Values.ingress .Values.ingress.enabled (gt (len .Values.ingress.hosts) 0)) (and .Values.webhook.url (hasPrefix "http" (.Values.webhook.url | toString))) }}
+- name: N8N_EDITOR_BASE_URL
+  valueFrom:
+    configMapKeyRef:
+      name: {{ include "n8n.fullname" . }}
+      key: N8N_EDITOR_BASE_URL
+{{- end }}
 {{- end }}
 
 {{/*
@@ -282,6 +296,13 @@ Environment variables from ConfigMap for worker pods (webhook URL for resume/wai
       name: {{ include "n8n.fullname" . }}
       key: WEBHOOK_URL
 {{- end }}
+{{- end }}
+{{- if or (and .Values.ingress .Values.ingress.enabled (gt (len .Values.ingress.hosts) 0)) (and .Values.webhook.url (hasPrefix "http" (.Values.webhook.url | toString))) }}
+- name: N8N_EDITOR_BASE_URL
+  valueFrom:
+    configMapKeyRef:
+      name: {{ include "n8n.fullname" . }}
+      key: N8N_EDITOR_BASE_URL
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
## Summary
- Fixes #148. The chart was writing `N8N_EDITOR_BASE_URL` into the ConfigMap, but no template referenced it as a container env var, so the value never reached the running n8n process even though the ConfigMap looked right. Editor links, OAuth callbacks, etc. came back empty.
- Wires the key into the main / worker / webhook-processor containers via `configMapKeyRef`, matching how `WEBHOOK_URL` is already done, and gates it on the same condition `configmap.yaml` uses so we never reference a missing key.

## Test plan
- [x] `helm lint charts/n8n`
- [x] `helm template` for three scenarios: ingress with hosts, `webhook.url=https://…` without ingress, and neither (env present, present, absent respectively)
- [x] Installed on OrbStack with the reporter's values (`webhook.url=https://n8n.example.com`, ingress off, queue mode + webhook processor). Confirmed `kubectl exec ... printenv N8N_EDITOR_BASE_URL` returns the configured URL on main, worker, and webhook-processor pods.

## Note for reviewers
Users on the documented `config.extraEnv` workaround will end up with the env name defined twice in the container spec. The `*ConfigMapEnv` helpers render before `config.extraEnv`, so in a Kubernetes env list the ConfigMap-sourced value wins. In practice the workaround value is the same URL the chart now derives, so behavior should be identical — but worth a release note.