### PR TITLE
docs: improve deployment guidance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
           - charts/n8n/examples/multi-main-queue.yaml
           - charts/n8n/examples/task-runners.yaml
           - charts/n8n/examples/keda-autoscaling.yaml
+          - charts/n8n/examples/https-ingress.yaml
           - charts/n8n/examples/production-s3.yaml
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ See the [chart README](./charts/n8n/README.md) for full documentation and the [e
 | [docker-compose/subfolderWithSSL](./docker-compose/subfolderWithSSL/) | n8n behind SSL reverse proxy in subfolder |
 | [docker-caddy](./docker-caddy/) | n8n with Caddy reverse proxy |
 
+## AWS CloudFormation (ECS Fargate)
+
+See [`aws-cloudformation/ecs-fargate/`](./aws-cloudformation/ecs-fargate/) for an AWS ECS Fargate example with multi-main queue mode, RDS PostgreSQL, ElastiCache Redis, S3 binary storage, HTTPS through an Application Load Balancer, and worker autoscaling.
+
 ## Kubernetes (Raw Manifests)
 
 See [`kubernetes/`](./kubernetes/) for raw Kubernetes manifest examples used in cloud provider tutorials (AWS, Azure, GCP).

--- a/aws-cloudformation/ecs-fargate/README.md
+++ b/aws-cloudformation/ecs-fargate/README.md
@@ -1,0 +1,93 @@
+# n8n on AWS ECS Fargate
+
+This directory contains a CloudFormation example for running n8n on ECS Fargate with multi-main queue mode.
+
+## Architecture
+
+The template deploys:
+
+- An internet-facing Application Load Balancer with HTTPS listener and HTTP-to-HTTPS redirect.
+- An ECS Fargate service for n8n main tasks behind the load balancer.
+- An ECS Fargate service for n8n worker tasks that consume jobs from Redis.
+- Amazon RDS PostgreSQL for the n8n database.
+- Amazon ElastiCache Redis for queue mode.
+- Amazon S3 for binary data storage.
+- Secrets Manager secrets for n8n license, encryption key, database credentials, and Redis password.
+
+Workers are not attached to the load balancer. They process queued executions from Redis and do not receive inbound HTTP requests.
+
+## Deployment Inputs
+
+Before deploying, provide:
+
+- A Route 53 hosted zone ID.
+- The n8n hostname to create in that hosted zone.
+- An ACM certificate ARN in the same AWS Region as the stack.
+- Production-grade database, Redis, license, and password values.
+
+The template includes placeholder defaults for some secrets so it is easy to inspect, but those values should be replaced before using the stack for a real deployment.
+
+## Worker Scaling
+
+The worker ECS service uses Application Auto Scaling target tracking. By default it scales on ECS service average CPU and memory:
+
+- `WorkerCpuTargetPercent`, default `60`.
+- `WorkerMemoryTargetPercent`, default `70`.
+- `WorkerScaleInCooldownSeconds`, default `60`.
+- `WorkerScaleOutCooldownSeconds`, default `60`.
+
+The current worker capacity knobs are:
+
+- `MainDesiredCount`, default `2`.
+- `WorkerDesiredCount`, default `3`.
+- `WorkerMinCapacity`, default `2`.
+- `WorkerMaxCapacity`, default `10`.
+- `WorkerConcurrency`, default `10`.
+
+Set `WorkerDesiredCount` between `WorkerMinCapacity` and `WorkerMaxCapacity`. Effective execution capacity is roughly:
+
+```text
+running worker tasks * WorkerConcurrency
+```
+
+n8n recommends worker concurrency of 5 or higher. Very low concurrency with many workers can increase database connection pressure without improving throughput.
+
+## Queue-Depth Scaling
+
+Queue-depth scaling is useful for n8n queue mode, but this template does not implement it directly.
+
+ElastiCache publishes cache and node-level metrics, not the Bull queue backlog key (`bull:default:wait`) that n8n workers consume. The template enables `N8N_METRICS=true` and `N8N_METRICS_INCLUDE_QUEUE_METRICS=true`, so n8n can expose queue metrics such as `n8n_scaling_mode_queue_jobs_waiting` from `/metrics`.
+
+To scale ECS workers from queue depth, publish a queue backlog metric to CloudWatch first. Common approaches are:
+
+- A Prometheus, OpenTelemetry, or CloudWatch agent pipeline that scrapes n8n `/metrics`.
+- A scheduled Lambda or small worker that reads the Redis queue length and publishes a custom CloudWatch metric.
+
+After that metric exists, add an Application Auto Scaling custom metric policy. Prefer a backlog-per-worker target instead of raw queue depth so scaling remains proportional to running capacity.
+
+## Monitoring
+
+Monitor at least:
+
+- ECS worker CPU and memory utilization.
+- ECS worker desired, running, and pending task counts.
+- RDS CPU, storage, and database connections.
+- ElastiCache CPU, memory, evictions, and connections.
+- n8n queue waiting, active, completed, and failed metrics from `/metrics`.
+
+## Validation
+
+Validate the template before deploying:
+
+```bash
+aws cloudformation validate-template \
+  --template-body file://aws-cloudformation/ecs-fargate/n8n-w-multimain-queuemode.yaml
+```
+
+If available, also run:
+
+```bash
+cfn-lint aws-cloudformation/ecs-fargate/n8n-w-multimain-queuemode.yaml
+```
+
+For production changes, create and review a CloudFormation change set in a non-production account before applying it.

--- a/aws-cloudformation/ecs-fargate/n8n-w-multimain-queuemode.yaml
+++ b/aws-cloudformation/ecs-fargate/n8n-w-multimain-queuemode.yaml
@@ -113,6 +113,63 @@ Parameters:
     Default: 1
     AllowedPattern: '^[0-9]+$'
 
+# ECS scaling parameters
+  MainDesiredCount:
+    Type: Number
+    Description: Number of ECS Fargate tasks to run for the n8n main service.
+    Default: 2
+    MinValue: 1
+
+  WorkerDesiredCount:
+    Type: Number
+    Description: Initial number of ECS Fargate tasks to run for the n8n worker service. Keep this between WorkerMinCapacity and WorkerMaxCapacity.
+    Default: 3
+    MinValue: 1
+
+  WorkerMinCapacity:
+    Type: Number
+    Description: Minimum ECS worker task count for Application Auto Scaling.
+    Default: 2
+    MinValue: 1
+
+  WorkerMaxCapacity:
+    Type: Number
+    Description: Maximum ECS worker task count for Application Auto Scaling. Must be greater than or equal to WorkerMinCapacity.
+    Default: 10
+    MinValue: 1
+
+  WorkerConcurrency:
+    Type: Number
+    Description: Number of queue jobs each worker task may process concurrently. n8n recommends 5 or higher.
+    Default: 10
+    MinValue: 5
+
+  WorkerCpuTargetPercent:
+    Type: Number
+    Description: Target average CPU utilization percentage for ECS worker target tracking.
+    Default: 60
+    MinValue: 1
+    MaxValue: 100
+
+  WorkerMemoryTargetPercent:
+    Type: Number
+    Description: Target average memory utilization percentage for ECS worker target tracking.
+    Default: 70
+    MinValue: 1
+    MaxValue: 100
+
+  WorkerScaleInCooldownSeconds:
+    Type: Number
+    Description: Cooldown period, in seconds, before worker CPU or memory policies scale in.
+    Default: 60
+    MinValue: 0
+
+  WorkerScaleOutCooldownSeconds:
+    Type: Number
+    Description: Cooldown period, in seconds, before worker CPU or memory policies scale out.
+    Default: 60
+    MinValue: 0
+
 # labels to make everything easier to read during setup
 Metadata:
   AWS::CloudFormation::Interface:
@@ -148,6 +205,18 @@ Metadata:
         Parameters:
           - RedisInstanceClass
           - RedisPassword
+      - Label:
+          default: "ECS Scaling Config"
+        Parameters:
+          - MainDesiredCount
+          - WorkerDesiredCount
+          - WorkerMinCapacity
+          - WorkerMaxCapacity
+          - WorkerConcurrency
+          - WorkerCpuTargetPercent
+          - WorkerMemoryTargetPercent
+          - WorkerScaleInCooldownSeconds
+          - WorkerScaleOutCooldownSeconds
 
 Resources:
 
@@ -1044,7 +1113,7 @@ Resources:
             TargetGroupArn: !Ref HttpAppTargetGroup
             ContainerName: "n8n"
             ContainerPort: 5678
-        DesiredCount: 2
+        DesiredCount: !Ref MainDesiredCount
         TaskDefinition: !Ref N8nMainTaskDefinition
         DeploymentConfiguration: 
             MaximumPercent: 200
@@ -1106,6 +1175,8 @@ Resources:
             - "node"
             - "/usr/local/bin/n8n"
             - "worker"
+          Command:
+            - !Sub "--concurrency=${WorkerConcurrency}"
           Secrets:
             - Name: N8N_LICENSE_ACTIVATION_KEY
               ValueFrom: !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:app-user/n8nlicense:LicenseKey::"
@@ -1232,7 +1303,7 @@ Resources:
     Properties:
         ServiceName: !Sub "${AWS::StackName}-svc-worker"
         Cluster: !GetAtt ECSCluster.Arn
-        DesiredCount: 3
+        DesiredCount: !Ref WorkerDesiredCount
         TaskDefinition: !Ref N8nWorkerTaskDefinition
         DeploymentConfiguration: 
             MaximumPercent: 200
@@ -1269,8 +1340,8 @@ Resources:
       ResourceId: !Sub 
         - "service/${ClusterName}/${ServiceName}"
         - { ClusterName: !Ref ECSCluster, ServiceName: !GetAtt ECSWorkerService.Name }
-      MinCapacity: 2
-      MaxCapacity: 10
+      MinCapacity: !Ref WorkerMinCapacity
+      MaxCapacity: !Ref WorkerMaxCapacity
       RoleARN: !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-service-role/ecs.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_ECSService"
 
   # scaling rules for CPU
@@ -1283,9 +1354,9 @@ Resources:
       TargetTrackingScalingPolicyConfiguration:
         PredefinedMetricSpecification:
           PredefinedMetricType: ECSServiceAverageCPUUtilization
-        TargetValue: 60
-        ScaleInCooldown: 60
-        ScaleOutCooldown: 60
+        TargetValue: !Ref WorkerCpuTargetPercent
+        ScaleInCooldown: !Ref WorkerScaleInCooldownSeconds
+        ScaleOutCooldown: !Ref WorkerScaleOutCooldownSeconds
 
   # scaling rules for memory
   ECSServiceMemoryScalingPolicy:
@@ -1297,9 +1368,9 @@ Resources:
       TargetTrackingScalingPolicyConfiguration:
         PredefinedMetricSpecification:
           PredefinedMetricType: ECSServiceAverageMemoryUtilization
-        TargetValue: 70
-        ScaleInCooldown: 60
-        ScaleOutCooldown: 60
+        TargetValue: !Ref WorkerMemoryTargetPercent
+        ScaleInCooldown: !Ref WorkerScaleInCooldownSeconds
+        ScaleOutCooldown: !Ref WorkerScaleOutCooldownSeconds
 
 # output useful information to make things easier to read.
 Outputs:

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -61,6 +61,7 @@ All three use the same n8n container image, differentiated by command/args.
 | [task-runners.yaml](./examples/task-runners.yaml) | Queue mode with task runner sidecars |
 | [production-s3.yaml](./examples/production-s3.yaml) | Production with S3, HPA, multi-main |
 | [keda-autoscaling.yaml](./examples/keda-autoscaling.yaml) | Redis queue-length scaling with KEDA |
+| [https-ingress.yaml](./examples/https-ingress.yaml) | HTTPS Ingress with TLS and webhook processor routing |
 
 ## Secret Management
 
@@ -69,6 +70,35 @@ All three use the same n8n container image, differentiated by command/args.
 3. **Redis password** (`redis.passwordSecret`): optional, for authenticated Redis — queue mode only
 
 For production, use an external secrets operator (e.g., [External Secrets Operator](https://external-secrets.io/)) rather than storing secrets in values files.
+
+## Ingress and HTTPS
+
+Set `ingress.enabled=true` to create the main Ingress for the n8n UI, API, and test webhooks. Configure `ingress.className`, controller-specific `ingress.annotations`, and `ingress.tls` for HTTPS termination. For cert-manager, add the issuer annotation and set `ingress.tls[].secretName` to the certificate Secret cert-manager should create.
+
+When `webhookProcessor.enabled=true`, enable `ingress.webhookProcessor.enabled` to create a second Ingress for production webhook traffic. The webhook processor Ingress routes `/webhook/`, `/webhook-waiting/`, `/form/`, and `/form-waiting/` to webhook processor pods. Test webhook paths such as `/webhook-test/` stay on the main Ingress.
+
+Use `ingress.sticky.enabled=true` for nginx cookie affinity, or `service.sessionAffinity.enabled=true` for Kubernetes `ClientIP` affinity. Multi-main deployments require sticky sessions at the load-balancing layer.
+
+See [https-ingress.yaml](./examples/https-ingress.yaml) for a complete HTTPS example.
+
+## Ports and Health Checks
+
+| Component | Port | Health check |
+|---|---:|---|
+| main | `service.port` (default `5678`) | HTTP liveness `/healthz`; readiness `/healthz/readiness` |
+| webhook-processor | `service.port` (default `5678`) | HTTP liveness `/healthz`; readiness `/healthz/readiness` |
+| worker | no Service | exec probe checks the `n8n worker` process |
+| task runner broker | `taskRunners.broker.port` (default `5679`) | localhost broker used by task runner sidecars |
+
+Workers consume jobs from Redis and do not receive inbound HTTP traffic, so the chart intentionally does not create a Kubernetes Service for worker pods.
+
+## Scaling Guidance
+
+Scale execution throughput with `queueMode.workerReplicaCount` and `queueMode.workerConcurrency`. The built-in HPA can scale main, worker, and webhook processor deployments from CPU and optional memory utilization.
+
+For queue-based scaling, enable `keda.enabled=true` and configure Redis triggers for workers. KEDA creates `ScaledObject` resources for workers, and optionally webhook processors, instead of the built-in worker/webhook HPAs.
+
+Webhook processors are an optional scaling layer for high-volume production webhook traffic. Enable them when webhook load should be isolated from the UI/API main pods, and configure ingress or load-balancer routing as described above.
 
 ## ServiceAccount
 

--- a/charts/n8n/examples/README.md
+++ b/charts/n8n/examples/README.md
@@ -15,6 +15,9 @@ This directory contains common configuration examples for different deployment s
 ### Community Examples (KEDA Autoscaling)
 - **[keda-autoscaling.yaml](./keda-autoscaling.yaml)** - Redis queue-length worker scaling with KEDA
 
+### Community Examples (Ingress)
+- **[https-ingress.yaml](./https-ingress.yaml)** - HTTPS ingress with TLS, sticky sessions, and webhook processor routing
+
 ### Community Examples (Node Placement)
 - **[node-placement.yaml](./node-placement.yaml)** - Pin `main` and webhook-processor to a stable node pool; run workers on an autoscaling pool
 
@@ -160,6 +163,7 @@ serviceAccount:
 
 **Connection issues:**
 - Enable session affinity: `service.sessionAffinity.enabled: true`
+- For nginx Ingress, enable cookie affinity: `ingress.sticky.enabled: true`
 - Check database SSL settings if using cloud databases
 
 **Storage issues:**
@@ -195,11 +199,14 @@ webhookProcessor:
 
 When `disableProductionWebhooksOnMainProcess: true`, configure your load balancer to route:
 - `/webhook/*` → webhook processor service (production webhooks)
+- `/webhook-waiting/*` → webhook processor service (waiting webhook responses)
 - `/form/*` → webhook processor service (production form triggers)
 - `/form-waiting/*` → webhook processor service (waiting form pages)
 - `/webhook-test/*` → main service (test webhooks)
 - `/form-test/*` → main service (test form triggers)
 - `/*` → main service (UI, API, everything else)
+
+The chart can create this split routing with `ingress.webhookProcessor.enabled=true`; see [https-ingress.yaml](./https-ingress.yaml).
 
 ### Testing
 ```bash

--- a/charts/n8n/examples/https-ingress.yaml
+++ b/charts/n8n/examples/https-ingress.yaml
@@ -1,0 +1,67 @@
+# Example: HTTPS ingress with optional webhook processor routing.
+#
+# Prerequisites:
+# - An ingress controller installed in the cluster.
+# - A TLS Secret named n8n-tls in the release namespace, or cert-manager
+#   configured to create it from the annotations below.
+# - External PostgreSQL and Redis services for queue mode.
+
+secretRefs:
+  existingSecret: "n8n-core-secrets"
+
+database:
+  useExternal: true
+  host: "postgres.example.internal"
+  passwordSecret:
+    name: "n8n-db-secret"
+    key: "password"
+
+redis:
+  enabled: true
+  useExternal: true
+  host: "redis.example.internal"
+  passwordSecret:
+    name: "n8n-redis-secret"
+    key: "password"
+
+queueMode:
+  enabled: true
+  workerReplicaCount: 2
+  workerConcurrency: 10
+
+webhookProcessor:
+  enabled: true
+  replicaCount: 2
+  disableProductionWebhooksOnMainProcess: true
+
+webhook:
+  url: "https://n8n.example.com"
+
+# Dedicated webhook ingress routes production webhook and form paths to
+# webhook-processor pods. Test webhook paths continue to route to the main
+# ingress through the catch-all "/" path above.
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  sticky:
+    enabled: true
+  hosts:
+    - host: n8n.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: n8n-tls
+      hosts:
+        - n8n.example.com
+  webhookProcessor:
+    enabled: true
+    className: nginx
+    annotations:
+      cert-manager.io/cluster-issuer: letsencrypt-prod
+    tls:
+      - secretName: n8n-tls
+        hosts:
+          - n8n.example.com

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -172,6 +172,18 @@ service:
 # ----- Ingress -----
 ingress:
   enabled: false
+  # IngressClass to use for the main n8n ingress. Examples: nginx, alb, traefik.
+  className: ""
+  # Controller-specific annotations. For cert-manager, set:
+  # cert-manager.io/cluster-issuer: letsencrypt-prod
+  annotations: {}
+  # TLS configuration for the main n8n ingress.
+  # Example:
+  # tls:
+  #   - secretName: n8n-tls
+  #     hosts:
+  #       - n8n.example.com
+  tls: []
   sticky:
     enabled: false
     cookieName: n8n_affinity


### PR DESCRIPTION
## Summary

This PR addresses current customer feedback around deployment discoverability and production guidance:

- documents the existing ECS/Fargate CloudFormation deployment path and makes it discoverable from the root README
- parameterizes ECS worker/main scaling defaults and worker concurrency without changing current behavior
- adds a Helm HTTPS ingress example with TLS, sticky sessions, and webhook processor routing
- documents existing Helm support for TLS, ports, health checks, sticky sessions, HPA/KEDA, and why workers do not have a Service
- adds the new HTTPS ingress example to CI template validation

Azure Container Apps ARM/Bicep support is intentionally out of scope for this repository change.

## Validation

- `helm lint charts/n8n`
- `helm template test charts/n8n -f charts/n8n/examples/https-ingress.yaml --dry-run=client`
- `helm template test charts/n8n -f charts/n8n/examples/production-s3.yaml --dry-run=client`
- full Helm example render matrix
- `cfn-lint --non-zero-exit-code error aws-cloudformation/ecs-fargate/n8n-w-multimain-queuemode.yaml`
- `git diff --check`

`cfn-lint` still reports warnings already present on `origin/main`; this change does not introduce new CloudFormation lint findings.
