### PR TITLE
feat(chart): add podLabels for pod templates

### DIFF
--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -126,6 +126,7 @@ To use the namespace's default ServiceAccount, set `name: ""`. If you set `creat
 | `ingress.enabled` | Create Ingress resource | `false` |
 | `persistence.enabled` | PVC for main pods | `false` |
 | `strategy` | Deployment update strategy | `{}` (k8s default) |
+| `podLabels` | Extra pod-template labels; overrides `commonLabels` on pods only | `{}` |
 | `hpa.main.enabled` | HPA for main pods | `false` |
 | `hpa.worker.enabled` | HPA for worker pods | `false` |
 | `keda.enabled` | KEDA queue-based autoscaling | `false` |

--- a/charts/n8n/templates/_helpers.tpl
+++ b/charts/n8n/templates/_helpers.tpl
@@ -38,6 +38,32 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
 {{/*
+Pod template labels. podLabels intentionally wins over commonLabels for
+user-defined keys on pods only; chart-managed selector/identity labels are
+always set by the chart.
+*/}}
+{{- define "n8n.podLabels" -}}
+{{- $root := .root -}}
+{{- $component := .component -}}
+{{- $labels := dict -}}
+{{- range $k, $v := ($root.Values.commonLabels | default dict) -}}
+{{- $_ := set $labels $k $v -}}
+{{- end -}}
+{{- $_ := set $labels "helm.sh/chart" (include "n8n.chart" $root) -}}
+{{- $_ := set $labels "app.kubernetes.io/name" (include "n8n.name" $root) -}}
+{{- $_ := set $labels "app.kubernetes.io/instance" $root.Release.Name -}}
+{{- if $root.Chart.AppVersion -}}
+{{- $_ := set $labels "app.kubernetes.io/version" $root.Chart.AppVersion -}}
+{{- end -}}
+{{- $_ := set $labels "app.kubernetes.io/managed-by" $root.Release.Service -}}
+{{- $_ := set $labels "app.kubernetes.io/component" $component -}}
+{{- range $k, $v := ($root.Values.podLabels | default dict) -}}
+{{- $_ := set $labels $k $v -}}
+{{- end -}}
+{{- toYaml $labels -}}
+{{- end -}}
+
+{{/*
 Selector labels
 */}}
 {{- define "n8n.selectorLabels" -}}
@@ -141,6 +167,17 @@ Validate values — called once from deployment-main.yaml to fail fast on bad co
 {{/* --- Service account --- */}}
 {{- if and (not .Values.serviceAccount.create) (eq .Values.serviceAccount.name "n8n") -}}
 {{- fail "serviceAccount.create=false but serviceAccount.name is still the chart default \"n8n\". Set serviceAccount.name to your pre-existing ServiceAccount, or to \"\" to use the namespace's default ServiceAccount." -}}
+{{- end -}}
+
+{{/* --- Pod labels --- */}}
+{{- $reservedPodLabels := list "app.kubernetes.io/name" "app.kubernetes.io/instance" "app.kubernetes.io/component" "app.kubernetes.io/version" "app.kubernetes.io/managed-by" "helm.sh/chart" -}}
+{{- range $k, $v := (.Values.podLabels | default dict) -}}
+{{- if has $k $reservedPodLabels -}}
+{{- fail (printf "podLabels.%q is a chart-managed selector/identity label and cannot be overridden. Reserved keys: %s" $k (join ", " $reservedPodLabels)) -}}
+{{- end -}}
+{{- if not (kindIs "string" $v) -}}
+{{- fail (printf "podLabels.%q must be a string (got %s). Kubernetes labels are map[string]string; quote numeric or boolean values, e.g. %q: \"true\"." $k (kindOf $v) $k) -}}
+{{- end -}}
 {{- end -}}
 
 {{- end -}}

--- a/charts/n8n/templates/deployment-main.yaml
+++ b/charts/n8n/templates/deployment-main.yaml
@@ -29,8 +29,7 @@ spec:
       annotations:
         {{- toYaml $podAnns | nindent 8 }}
       labels:
-        {{- include "n8n.labels" . | nindent 8 }}
-        app.kubernetes.io/component: main
+        {{- include "n8n.podLabels" (dict "root" . "component" "main") | nindent 8 }}
     spec:
       {{- with include "n8n.serviceAccountName" . }}
       serviceAccountName: {{ . }}

--- a/charts/n8n/templates/deployment-webhook-processor.yaml
+++ b/charts/n8n/templates/deployment-webhook-processor.yaml
@@ -25,8 +25,7 @@ spec:
       annotations:
         {{- toYaml $podAnns | nindent 8 }}
       labels:
-        {{- include "n8n.labels" . | nindent 8 }}
-        app.kubernetes.io/component: webhook-processor
+        {{- include "n8n.podLabels" (dict "root" . "component" "webhook-processor") | nindent 8 }}
     spec:
       {{- with include "n8n.serviceAccountName" . }}
       serviceAccountName: {{ . }}

--- a/charts/n8n/templates/deployment-worker.yaml
+++ b/charts/n8n/templates/deployment-worker.yaml
@@ -25,8 +25,7 @@ spec:
       annotations:
         {{- toYaml $podAnns | nindent 8 }}
       labels:
-        {{- include "n8n.labels" . | nindent 8 }}
-        app.kubernetes.io/component: worker
+        {{- include "n8n.podLabels" (dict "root" . "component" "worker") | nindent 8 }}
     spec:
       {{- with include "n8n.serviceAccountName" . }}
       serviceAccountName: {{ . }}

--- a/charts/n8n/values.schema.json
+++ b/charts/n8n/values.schema.json
@@ -324,7 +324,11 @@
       }
     },
     "podAnnotations": { "type": "object", "additionalProperties": true },
-    "podLabels": { "type": "object", "additionalProperties": true },
+    "podLabels": {
+      "type": "object",
+      "additionalProperties": { "type": "string" },
+      "default": {}
+    },
     "securityContext": {
       "type": "object",
       "properties": {

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -153,6 +153,16 @@ taskRunners:
 # to avoid Multi-Attach errors during upgrades.
 strategy: {}
 
+# ----- Pod Labels -----
+# Extra labels added to main / worker / webhook-processor pod templates.
+# When a key exists in both commonLabels and podLabels, podLabels wins on pod
+# templates only. Chart-managed labels cannot be overridden here.
+# Useful for opt-in admission webhooks and pod selectors, for example:
+# podLabels:
+#   azure.workload.identity/use: "true"
+#   sidecar.istio.io/inject: "true"
+podLabels: {}
+
 # ----- Main replicas (when multi-main is disabled) -----
 replicaCount: 1
 


### PR DESCRIPTION
## Summary

Adds top-level `podLabels` support for the n8n Helm chart pod templates, covering main, worker, and webhook-processor Deployments.

This supersedes #119 with a merged implementation that works with the current `commonLabels` support on `main`. Pod template labels are now rendered from one merged map, so overlapping `commonLabels` and `podLabels` keys do not produce duplicate YAML labels. For non-reserved user labels, `podLabels` wins on pod templates only.

## Details

- Adds `podLabels: {}` to values and schema with string-only label values.
- Adds a pod label helper that preserves chart-managed selector and identity labels.
- Rejects `podLabels` attempts to override chart-managed labels.
- Documents that `podLabels` overrides `commonLabels` only on pod templates.

## Validation

- `helm lint charts/n8n`
- Rendered the existing CI example matrix with `helm template --dry-run=client`.
- Verified `podLabels` render on main, worker, and webhook-processor pod templates.
- Verified overlapping `commonLabels` / `podLabels` emits one pod label with the `podLabels` value.
- Verified reserved chart labels and non-string `podLabels` fail validation.
