### PR TITLE
Allow more customization for security contexts

### DIFF
--- a/charts/n8n/examples/multi-main-queue.yaml
+++ b/charts/n8n/examples/multi-main-queue.yaml
@@ -170,10 +170,11 @@ secretRefs:
   existingSecret: "n8n-enterprise-secrets"
 
 # Enterprise security settings
-securityContext:
+podSecurityContext:
+  fsGroup: 1000
   runAsNonRoot: true
   runAsUser: 1000
-  fsGroup: 1000
+  runAsGroup: 1000
   seccompProfile:
     type: RuntimeDefault
 

--- a/charts/n8n/examples/production-s3.yaml
+++ b/charts/n8n/examples/production-s3.yaml
@@ -182,10 +182,13 @@ probes:
     failureThreshold: 3
 
 # Security context
-securityContext:
+podSecurityContext:
+  fsGroup: 1000
   runAsNonRoot: true
   runAsUser: 1000
-  fsGroup: 1000
+  runAsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
 
 # Pod disruption budget for high availability
 podDisruptionBudget:

--- a/charts/n8n/templates/deployment-main.yaml
+++ b/charts/n8n/templates/deployment-main.yaml
@@ -38,15 +38,8 @@ spec:
       automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       {{- end }}
 
-      {{- if .Values.securityContext.enabled }}
       securityContext:
-        fsGroup: {{ .Values.securityContext.fsGroup }}
-        runAsUser: {{ .Values.securityContext.runAsUser }}
-        runAsGroup: {{ .Values.securityContext.runAsGroup }}
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
-      {{- end }}
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
 
       {{- with .Values.dnsPolicy }}
       dnsPolicy: {{ . }}
@@ -70,10 +63,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
 
           {{- if .Values.lifecycle.main.preStop.enabled }}
           lifecycle:
@@ -203,10 +193,7 @@ spec:
           image: "{{ .Values.taskRunners.image.repository }}:{{ default .Values.image.tag .Values.taskRunners.image.tag }}"
           imagePullPolicy: {{ .Values.taskRunners.image.pullPolicy }}
           securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
+            {{- toYaml .Values.taskRunners.containerSecurityContext | nindent 12 }}
 
           env:
             {{- include "n8n.taskRunnerSidecarEnv" . | nindent 12 }}

--- a/charts/n8n/templates/deployment-webhook-processor.yaml
+++ b/charts/n8n/templates/deployment-webhook-processor.yaml
@@ -34,15 +34,8 @@ spec:
       automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       {{- end }}
 
-      {{- if .Values.securityContext.enabled }}
       securityContext:
-        fsGroup: {{ .Values.securityContext.fsGroup }}
-        runAsUser: {{ .Values.securityContext.runAsUser }}
-        runAsGroup: {{ .Values.securityContext.runAsGroup }}
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
-      {{- end }}
+        {{- toYaml .Values.webhookProcessor.podSecurityContext | nindent 8 }}
 
       {{- with .Values.dnsPolicy }}
       dnsPolicy: {{ . }}
@@ -68,10 +61,7 @@ spec:
           command: ["n8n"]
           args: ["webhook"]
           securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
+            {{- toYaml .Values.webhookProcessor.containerSecurityContext | nindent 12 }}
 
           {{- if .Values.lifecycle.webhookProcessor.preStop.enabled }}
           lifecycle:

--- a/charts/n8n/templates/deployment-worker.yaml
+++ b/charts/n8n/templates/deployment-worker.yaml
@@ -34,15 +34,8 @@ spec:
       automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       {{- end }}
 
-      {{- if .Values.securityContext.enabled }}
       securityContext:
-        fsGroup: {{ .Values.securityContext.fsGroup }}
-        runAsUser: {{ .Values.securityContext.runAsUser }}
-        runAsGroup: {{ .Values.securityContext.runAsGroup }}
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
-      {{- end }}
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
 
       {{- with .Values.dnsPolicy }}
       dnsPolicy: {{ . }}
@@ -70,10 +63,7 @@ spec:
             - "worker"
             - "--concurrency={{ .Values.queueMode.workerConcurrency }}"
           securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
 
           {{- if .Values.lifecycle.worker.preStop.enabled }}
           lifecycle:
@@ -199,10 +189,7 @@ spec:
           image: "{{ .Values.taskRunners.image.repository }}:{{ default .Values.image.tag .Values.taskRunners.image.tag }}"
           imagePullPolicy: {{ .Values.taskRunners.image.pullPolicy }}
           securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
+            {{- toYaml .Values.taskRunners.containerSecurityContext | nindent 12 }}
 
           env:
             {{- include "n8n.taskRunnerSidecarEnv" . | nindent 12 }}

--- a/charts/n8n/values.schema.json
+++ b/charts/n8n/values.schema.json
@@ -16,6 +16,20 @@
       "required": ["repository", "tag"]
     },
     "replicaCount": { "type": "integer", "minimum": 1 },
+    "nameOverride": { "type": "string" },
+    "fullnameOverride": { "type": "string" },
+    "strategy": {
+      "type": "object",
+      "description": "Deployment strategy for the main n8n Deployment"
+    },
+    "containerSecurityContext": {
+      "type": "object",
+      "description": "Container-level security context for n8n containers"
+    },
+    "podSecurityContext": {
+      "type": "object",
+      "description": "Pod-level security context for n8n pods"
+    },
     "commonLabels": {
       "type": "object",
       "additionalProperties": { "type": "string" },
@@ -147,6 +161,10 @@
             }
           }
         },
+        "containerSecurityContext": {
+          "type": "object",
+          "description": "Container-level security context for task runner sidecars"
+        },
         "extraEnv": {
           "type": "array",
           "items": { "type": "object" }
@@ -180,6 +198,14 @@
         "enabled": { "type": "boolean" },
         "replicaCount": { "type": "integer", "minimum": 1 },
         "disableProductionWebhooksOnMainProcess": { "type": "boolean" },
+        "podSecurityContext": {
+          "type": "object",
+          "description": "Pod-level security context for webhook-processor pods"
+        },
+        "containerSecurityContext": {
+          "type": "object",
+          "description": "Container-level security context for webhook-processor containers"
+        },
         "extraEnv": {
           "type": "array",
           "items": {
@@ -200,6 +226,18 @@
         "type": { "type": "string" },
         "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
         "annotations": { "type": "object", "additionalProperties": true },
+        "main": {
+          "type": "object",
+          "properties": {
+            "annotations": { "type": "object", "additionalProperties": true }
+          }
+        },
+        "webhookProcessor": {
+          "type": "object",
+          "properties": {
+            "annotations": { "type": "object", "additionalProperties": true }
+          }
+        },
         "sessionAffinity": {
           "type": "object",
           "properties": {
@@ -275,7 +313,8 @@
       "type": "object",
       "properties": {
         "main": { "type": "object" },
-        "worker": { "type": "object" }
+        "worker": { "type": "object" },
+        "webhookProcessor": { "type": "object" }
       }
     },
     "nodeSelector": {
@@ -329,22 +368,106 @@
       "additionalProperties": { "type": "string" },
       "default": {}
     },
-    "securityContext": {
-      "type": "object",
-      "properties": {
-        "enabled": { "type": "boolean" },
-        "fsGroup": { "type": "integer", "minimum": 0 },
-        "runAsUser": { "type": "integer", "minimum": 0 },
-        "runAsGroup": { "type": "integer", "minimum": 0 }
-      }
-    },
     "serviceAccount": {
       "type": "object",
       "properties": {
         "create": { "type": "boolean" },
         "name": { "type": "string" },
+        "awsRoleArn": { "type": "string" },
         "annotations": { "type": "object", "additionalProperties": true },
         "automountServiceAccountToken": { "type": "boolean" }
+      }
+    },
+    "networkPolicy": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
+    },
+    "pdb": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "minAvailable": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "lifecycle": {
+      "type": "object",
+      "properties": {
+        "main": {
+          "type": "object",
+          "properties": {
+            "terminationGracePeriodSeconds": { "type": "integer", "minimum": 0 },
+            "preStop": {
+              "type": "object",
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "command": {
+                  "type": "array",
+                  "items": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        "worker": {
+          "type": "object",
+          "properties": {
+            "terminationGracePeriodSeconds": { "type": "integer", "minimum": 0 },
+            "preStop": {
+              "type": "object",
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "command": {
+                  "type": "array",
+                  "items": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        "webhookProcessor": {
+          "type": "object",
+          "properties": {
+            "terminationGracePeriodSeconds": { "type": "integer", "minimum": 0 },
+            "preStop": {
+              "type": "object",
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "command": {
+                  "type": "array",
+                  "items": { "type": "string" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "keda": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "worker": {
+          "type": "object",
+          "properties": {
+            "pollingInterval": { "type": "integer", "minimum": 1 },
+            "cooldownPeriod": { "type": "integer", "minimum": 1 },
+            "minReplicaCount": { "type": "integer", "minimum": 0 },
+            "maxReplicaCount": { "type": "integer", "minimum": 1 },
+            "triggers": { "type": "array" }
+          }
+        },
+        "webhookProcessor": {
+          "type": "object",
+          "properties": {
+            "pollingInterval": { "type": "integer", "minimum": 1 },
+            "cooldownPeriod": { "type": "integer", "minimum": 1 },
+            "minReplicaCount": { "type": "integer", "minimum": 0 },
+            "maxReplicaCount": { "type": "integer", "minimum": 1 },
+            "triggers": { "type": "array" }
+          }
+        }
       }
     },
     "extraInitContainers": {
@@ -439,20 +562,43 @@
     "hpa": {
       "type": "object",
       "properties": {
-        "enabled": { "type": "boolean" },
-        "minReplicas": { "type": "integer", "minimum": 1 },
-        "maxReplicas": { "type": "integer", "minimum": 1 },
-        "targetCPUUtilizationPercentage": {
-          "type": "integer",
-          "minimum": 1,
-          "maximum": 100
-        },
-        "targetMemoryUtilizationPercentage": {
-          "type": "integer",
-          "minimum": 1,
-          "maximum": 100
+        "main": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "minReplicas": { "type": "integer", "minimum": 1 },
+            "maxReplicas": { "type": "integer", "minimum": 1 },
+            "targetCPUUtilizationPercentage": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "targetMemoryUtilizationPercentage": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            }
+          }
         },
         "worker": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "minReplicas": { "type": "integer", "minimum": 1 },
+            "maxReplicas": { "type": "integer", "minimum": 1 },
+            "targetCPUUtilizationPercentage": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "targetMemoryUtilizationPercentage": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            }
+          }
+        },
+        "webhookProcessor": {
           "type": "object",
           "properties": {
             "enabled": { "type": "boolean" },
@@ -594,6 +740,7 @@
         "host": { "type": "string" },
         "port": { "type": "integer" },
         "database": { "type": "string" },
+        "schema": { "type": "string" },
         "user": { "type": "string" },
         "passwordSecret": {
           "type": "object",
@@ -602,6 +749,16 @@
             "key": { "type": "string" }
           },
           "required": ["name", "key"]
+        },
+        "ssl": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "ca": { "type": "string" },
+            "cert": { "type": "string" },
+            "key": { "type": "string" },
+            "rejectUnauthorized": { "type": "boolean" }
+          }
         }
       },
       "additionalProperties": true
@@ -609,6 +766,8 @@
     "redis": {
       "type": "object",
       "properties": {
+        "enabled": { "type": "boolean" },
+        "useExternal": { "type": "boolean" },
         "host": { "type": "string" },
         "port": { "type": "integer" },
         "username": { "type": "string" },

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -60,6 +60,25 @@ webhookProcessor:
   #   - name: N8N_LOG_LEVEL
   #     value: "debug"
   extraEnv: []
+  # -- Security Context for the whole pod.
+  podSecurityContext:
+    fsGroup: 1000
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+    seccompProfile:
+      type: RuntimeDefault
+  # -- Container Security Context.
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: false
+    runAsUser: 1000
+    runAsGroup: 1000
+    seccompProfile:
+      type: RuntimeDefault
 
 # ----- Multi-main (optional, requires queue mode) -----
 multiMain:
@@ -140,6 +159,21 @@ taskRunners:
     limits:
       cpu: 500m
       memory: 512Mi
+
+  # -- Container Security Context.
+  # If you use a distroless image (tag with "x.xx.x-distroless")
+  # You may want to set runAsUser and runAsGroup to 65532
+  # Ref: https://docs.n8n.io/deploy/host-n8n/configure-n8n/security/harden-task-runners#use-the-distroless-image
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: false
+    runAsUser: 1000
+    runAsGroup: 1000
+    seccompProfile:
+      type: RuntimeDefault
 
   # Additional environment variables for task runners
   extraEnv: []
@@ -337,14 +371,29 @@ nodePlacement: {}
 #         effect: NoSchedule
 
 # ----- Security -----
-# Note: readOnlyRootFilesystem is intentionally not set. n8n writes to
+# -- Container Security Context.
+# Note: readOnlyRootFilesystem is intentionally not set to true. n8n writes to
 # ~/.n8n/, /tmp/, and other paths at runtime. Enabling it would require
 # extensive volumeMount overrides and is not practical for this workload.
-securityContext:
-  enabled: true
-  fsGroup: 1000
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: false
   runAsUser: 1000
   runAsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+# -- Security Context for the whole pod.
+podSecurityContext:
+  fsGroup: 1000
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
 
 # ----- RBAC ServiceAccount & Network Policy -----
 rbac:


### PR DESCRIPTION
# Pull Request
Allow a more flexible way to configure security context accross the differents containers.
Allow also to achieve the hardening recommandation [here](https://docs.n8n.io/deploy/host-n8n/configure-n8n/security/harden-task-runners#use-the-distroless-image) 

## Description
Brief description of the changes and their purpose.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Example/configuration update
- [ ] CI/CD improvements

## Related Issues
Fixes # (issue)
Relates to # (issue)

## Changes Made
Remove `SecurityContext` and split it in `podSecurityContext` and `containerSecurityContext`

## Testing Performed
I have fully deployed it and also be able to set custom user and group id for runners.

### Chart Validation
- [x] `helm lint charts/n8n` passes
- [x] `./scripts/validate-examples.sh` passes
- [x] Template rendering works with all examples

### Deployment Testing (if applicable)
- [ ] Tested with minimal configuration
- [x] Tested with production configuration
- [x] Tested upgrade path from previous version
- [x] All pods start successfully
- [x] Application is accessible

### Specific Testing for Changes
Describe any specific testing you performed for your changes:
- Deploy the chart using the following values file:
```yaml
image:
  repository: docker.n8n.io/n8nio/n8n
  tag: "stable"

fullnameOverride: easi-n8n

queueMode:
  enabled: true
  workerReplicaCount: 5
  workerConcurrency: 10

strategy:
  type: Recreate

database:
  type: postgresdb
  useExternal: true
  host: n8n-rw
  port: 5432
  database: n8n
  schema: public
  user: n8n
  passwordSecret:
    name: n8n-app
    key: password

redis:
  enabled: true
  useExternal: true
  host: valkey
  port: 6379
  username: "
  passwordSecret:
    name: valkey-auth
    key: default-password
  tls: false
  healthCheck:
    enabled: false
    port: 5678

taskRunners:
  enabled: true
  image:
    repository: n8nio/runners
    tag: "2.26.9-distroless"
  authToken:
    existingSecret: n8n-encryption-key
    existingSecretKey: N8N_TASK_RUNNERS_AUTH_TOKEN
  # Needed for distroless deployment
  # Ref: https://docs.n8n.io/deploy/host-n8n/configure-n8n/security/harden-task-runners#use-the-distroless-image
  containerSecurityContext:
    allowPrivilegeEscalation: false
    capabilities:
      drop:
        - ALL
    readOnlyRootFilesystem: true
    runAsUser: 65532
    runAsGroup: 65532
    seccompProfile:
      type: RuntimeDefault

secretRefs:
  existingSecret: n8n-encryption-key

config:
  timezone: Europe/Paris
  extraEnvFrom:
    - configMapRef:
        name: n8n-env
  extraEnv:
    - name: N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS
      value: "true"
    - name: N8N_PROXY_HOPS
      value: "1"

executions:
  concurrency:
    productionLimit: 50
  timeout: 3600 # 1 hour
  data:
    saveOnError: "all"
    saveOnSuccess: "all"
    saveOnProgress: false
    saveManualExecutions: true
  pruning:
    enabled: true
    maxAge: 336 # 14 days in hours
    maxCount: 10000
    hardDeleteBuffer: 1 # 1 hour buffer before hard delete
    hardDeleteInterval: 15 # minutes between hard delete runs
    softDeleteInterval: 60 # minutes between soft delete runs

serviceAccount:
  name: easi-n8n
  automountServiceAccountToken: false

dnsConfig:
  options:
    - name: ndots
      value: "1"

resources:
  main:
    limits:
      cpu: "2"
      ephemeral-storage: 1Gi
      memory: 4Gi
    requests:
      cpu: 500m
      ephemeral-storage: "0"
      memory: 512Mi

ingress:
  enabled: true
  className: nginx
  annotations:
    cert-manager.io/cluster-issuer: letsencrypt-prod
  hosts:
    - host: easi-n8n.youpi.fr
      paths:
        - path: /
          pathType: Prefix
  tls:
    - secretName: n8n-tls
      hosts:
        - easi-n8n.youpi.fr

pdb:
  enabled: false

# /tmp as mount
# # Needed for distroless deployment
# Ref: https://docs.n8n.io/deploy/host-n8n/configure-n8n/security/harden-task-runners#use-the-distroless-image
extraVolumes:
  - name: tmp
    emptyDir: {}

extraVolumeMounts:
  - name: tmp
    mountPath: /tmp

# This could be defined but that the new default values
# containerSecurityContext:
#   allowPrivilegeEscalation: false
#   capabilities:
#     drop:
#       - ALL
#   readOnlyRootFilesystem: false
#   runAsUser: 1000
#   runAsGroup: 1000
#   seccompProfile:
#     type: RuntimeDefault

# # -- Security Context for the whole pod.
# podSecurityContext:
#   fsGroup: 1000
#   runAsNonRoot: true
#   runAsUser: 1000
#   runAsGroup: 1000
#   seccompProfile:
#     type: RuntimeDefault

```

## Breaking Changes
If this includes breaking changes, describe what they are and provide migration instructions:
Yes. The old `SecurityContext` has been split into `podSecurityContext` and `containerSecurityContext`.

The best approach is to remove `SecurityContext`, as it will be silently ignored, and replace it with `podSecurityContext` and/or `containerSecurityContext`, which provide more granular configuration and customization capabilities.
Or let the default values do the job.. :)


## Documentation Updates
- [ ] Updated Chart.yaml version (if needed)
- [ ] Updated CHANGELOG.md
- [ ] Updated README.md (if needed)
- [ ] Updated examples (if needed)
- [ ] Updated CONTRIBUTING.md (if needed)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added examples that demonstrate the changes (if applicable)
- [x] All new and existing tests pass

## Screenshots (if applicable)
Add screenshots to help explain your changes.

## Additional Notes
Any additional information that reviewers should know.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the old `securityContext` into pod-level and container-level settings across main, worker, webhook-processor, and task-runner sidecars to enable stricter hardening and support distroless runners.

- **New Features**
  - Added `.Values.podSecurityContext` and `.Values.containerSecurityContext` for main and worker.
  - Added `.Values.webhookProcessor.podSecurityContext` and `.Values.webhookProcessor.containerSecurityContext`.
  - Added `.Values.taskRunners.containerSecurityContext`.
  - Templates now render via `toYaml` for full control of `seccompProfile`, `runAs*`, `capabilities`, and `readOnlyRootFilesystem`.
  - Defaults in `values.yaml` mirror previous behavior; `readOnlyRootFilesystem` remains false. Examples updated to use `podSecurityContext` with `runAsGroup` and `seccompProfile`.

- **Migration**
  - Replace `securityContext.*` (including `enabled`) with:
    - `podSecurityContext` and `containerSecurityContext` (main/worker)
    - `webhookProcessor.podSecurityContext` and `.containerSecurityContext`
    - `taskRunners.containerSecurityContext`
  - Review `runAs*`, `capabilities.drop: [ALL]`, and `seccompProfile: RuntimeDefault`.
  - For distroless task runners, set `runAsUser`/`runAsGroup` to `65532`.

<sup>Written for commit 2bc91bdaa1106495fbbc0c82e5855ec4358381f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-hosting/pull/160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



