### PR TITLE
fix(chart): report actual database in NOTES.txt for standalone mode

### DIFF
--- a/charts/n8n/templates/NOTES.txt
+++ b/charts/n8n/templates/NOTES.txt
@@ -39,15 +39,20 @@ Deployment Configuration:
 {{- if .Values.webhookProcessor.enabled }}
   - Webhook processors: {{ .Values.webhookProcessor.replicaCount }} pods
 {{- end }}
-  - Database: PostgreSQL ({{ .Values.database.host }})
+{{- else }}
+  - Mode: Standalone
+  - Main pods: {{ .Values.replicaCount }}
+{{- end }}
+{{- if .Values.database.useExternal }}
+  - Database: {{ if eq .Values.database.type "postgresdb" }}PostgreSQL{{ else }}{{ .Values.database.type }}{{ end }} ({{ .Values.database.host }})
+{{- else }}
+  - Database: SQLite (local storage)
+{{- end }}
+{{- if .Values.redis.enabled }}
   - Cache: Redis ({{ .Values.redis.host }})
+{{- end }}
 {{- if .Values.s3.enabled }}
   - Storage: S3 ({{ .Values.s3.bucket.name }})
-{{- end }}
-{{- else }}
-  - Mode: Standalone (SQLite)
-  - Main pods: {{ .Values.replicaCount }}
-  - Database: SQLite (local storage)
 {{- end }}
 
 Documentation: https://docs.n8n.io/


### PR DESCRIPTION
Closes #161.

`NOTES.txt` branched the Mode/Database/Cache lines solely on `queueMode.enabled`, so a standalone deployment (`queueMode.enabled=false`) always reported `Mode: Standalone (SQLite)` / `Database: SQLite (local storage)` — even when configured with an external database (`database.useExternal=true`, `database.type=postgresdb`). In that case the ConfigMap already renders `DB_TYPE: postgresdb` and the pod connects to PostgreSQL; only the NOTES text was wrong.

This decouples the Database line from `queueMode`:

- Database is derived from `database.useExternal` / `database.type`
- Cache (Redis) is gated on `redis.enabled`
- the standalone Mode line no longer hardcodes `(SQLite)`

Resulting NOTES:

- standalone + external Postgres → `Mode: Standalone`, `Database: PostgreSQL (<host>)`
- standalone, no external DB → `Mode: Standalone`, `Database: SQLite (local storage)`
- queue mode → unchanged (`PostgreSQL` + `Redis`)

Verified with `helm lint charts/n8n` (passes) and `helm template`. `Chart.yaml` is intentionally left unbumped (handled by semantic-release).

Note: this changes a chart template, so per CONTRIBUTING the `test-install` label should be added to trigger the kind install test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Helm chart `NOTES.txt` so standalone deployments report the actual database instead of always showing SQLite. Also gates the cache line on `redis.enabled`; queue mode output is unchanged.

- **Bug Fixes**
  - Database derived from `database.useExternal` / `database.type` (shows host when external), else "SQLite (local storage)".
  - Cache line only when `redis.enabled`; S3 line only when `s3.enabled`.
  - Standalone Mode no longer hardcodes "(SQLite)".
  - Verified with `helm lint` and `helm template`. Please add the `test-install` label to run the kind install test.

<sup>Written for commit aa7406eb80b85296def258519d03725b183fa60e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-hosting/pull/162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

