### PR TITLE
fix(aws-cloudformation): make S3 binary bucket name globally unique

### DIFF
--- a/aws-cloudformation/ecs-fargate/n8n-w-multimain-queuemode.yaml
+++ b/aws-cloudformation/ecs-fargate/n8n-w-multimain-queuemode.yaml
@@ -592,7 +592,11 @@ Resources:
     Properties:
       VersioningConfiguration:
         Status: Enabled
-      BucketName: !Sub "${AWS::StackName}-n8n-bin"
+      # BucketName intentionally omitted: CloudFormation auto-generates a
+      # globally-unique, length-safe, lowercase name. An explicit name like
+      # "${AWS::StackName}-n8n-bin" collides in S3's global namespace, can
+      # exceed the 63-char limit, and breaks on uppercase stack names.
+      # Everything references the bucket via !Ref S3BinaryBucket.
   
   # directly attach bucket policy
   S3BucketPolicy:


### PR DESCRIPTION
## What

Remove the explicit `BucketName` from `S3BinaryBucket` and let CloudFormation auto-generate it.

## Why

`S3BinaryBucket` hardcoded `BucketName: !Sub "${AWS::StackName}-n8n-bin"`. An explicit, deterministic name is the wrong call for an S3 bucket, for three reasons:

1. **Global-namespace collision (original bug).** S3 bucket names share a single global namespace across all AWS accounts and regions, so a generic name like `n8n-n8n-bin` (stack name `n8n`) collides with any account that already deployed the template:
   ```
   The requested bucket name is not available. The bucket namespace is
   shared by all users of the system. (S3, 409, AlreadyExists)
   ```
   The bucket failure then cancels every other resource and the whole stack rolls back with a confusing "creation cancelled" cascade. Hit on a real first-time deploy.
2. **63-char limit** (raised in review by @cubic-dev-ai): a long stack name pushes the name past S3's limit.
3. **Uppercase stack names**: stack names may contain uppercase, but S3 bucket names must be lowercase — so an uppercase stack name would also fail.

## Fix

Drop the explicit `BucketName`. CloudFormation then auto-generates a name that is globally unique, length-safe, and lowercase by construction. Every reference uses `!Ref S3BinaryBucket` (bucket policy, IAM, `N8N_EXTERNAL_STORAGE_S3_BUCKET_NAME`, console output), so nothing depends on a predictable literal name.

## Validation

- `cfn-lint 1.52.0`: no new findings from this change (remaining warnings are pre-existing and unrelated).
- Base template verified on a live deploy: `CREATE_COMPLETE`, n8n served over HTTPS (`/healthz/readiness` 200), binary storage on the auto-named bucket.

## Scope

Only the base template (`n8n-w-multimain-queuemode.yaml`) is on `main`, so this PR fixes that file. The webhooks/HA templates carry the identical line and should get the same change when they land upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
