### PR TITLE
docs: clarify supported infra versions and align example image tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ confirm against the linked n8n docs for the release you're deploying.
 | Component | Supported / recommended | Notes |
 |---|---|---|
 | n8n | Latest stable release | Pin a specific image tag for production rather than relying on `stable`/`latest`. |
-| PostgreSQL | Actively-maintained releases; **13+** recommended for queue mode | Recommended database for production. |
+| PostgreSQL | Any actively-maintained release | Recommended database for production. n8n documents **13** as the queue-mode minimum, but prefer a still-supported major. |
 | SQLite | Bundled | Default when queue mode is off. Fine for development and small single-instance setups. |
 | MySQL / MariaDB | **Not supported** | Deprecated as the n8n backend in v1.0 and removed in v2.0 -- use PostgreSQL. (The MySQL *node* is unaffected.) |
-| Redis | **6+** recommended | Only needed for queue mode. Redis 6+ is required if you set a Redis username. |
+| Redis | **7+** recommended | Only needed for queue mode. Redis 6+ is required if you set a Redis username. |
 | Valkey | Redis-compatible drop-in for queue mode | Not separately version-guaranteed by n8n; verify against your n8n release. |
 
 For the authoritative details, see:

--- a/README.md
+++ b/README.md
@@ -2,12 +2,33 @@
 
 Official hosting configurations for [n8n](https://n8n.io) -- the workflow automation platform.
 
+## Requirements & supported versions
+
+n8n doesn't publish a version-by-version support matrix -- its policy is to support
+actively-maintained releases of its dependencies. Use the table below as a starting point and
+confirm against the linked n8n docs for the release you're deploying.
+
+| Component | Supported / recommended | Notes |
+|---|---|---|
+| n8n | Latest stable release | Pin a specific image tag for production rather than relying on `stable`/`latest`. |
+| PostgreSQL | Actively-maintained releases; **13+** recommended for queue mode | Recommended database for production. |
+| SQLite | Bundled | Default when queue mode is off. Fine for development and small single-instance setups. |
+| MySQL / MariaDB | **Not supported** | Deprecated as the n8n backend in v1.0 and removed in v2.0 -- use PostgreSQL. (The MySQL *node* is unaffected.) |
+| Redis | **6+** recommended | Only needed for queue mode. Redis 6+ is required if you set a Redis username. |
+| Valkey | Redis-compatible drop-in for queue mode | Not separately version-guaranteed by n8n; verify against your n8n release. |
+
+For the authoritative details, see:
+
+- [Supported databases and settings](https://docs.n8n.io/hosting/configuration/supported-databases-settings/)
+- [Configuring queue mode](https://docs.n8n.io/hosting/scaling/queue-mode/)
+- [Queue mode environment variables](https://docs.n8n.io/hosting/configuration/environment-variables/queue-mode/) (Redis)
+
 ## Kubernetes (Helm Chart)
 
 The official n8n Helm chart for production Kubernetes deployments.
 
 ```bash
-helm install n8n oci://ghcr.io/n8n-io/n8n-helm-chart/n8n --version 1.0.0 -f my-values.yaml
+helm install n8n oci://ghcr.io/n8n-io/n8n-helm-chart/n8n -f my-values.yaml
 ```
 
 See the [chart README](./charts/n8n/README.md) for full documentation and the [examples](./charts/n8n/examples/) directory for common configurations.

--- a/charts/n8n/examples/README.md
+++ b/charts/n8n/examples/README.md
@@ -59,7 +59,7 @@ helm install n8n ./charts/n8n -f my-values.yaml
 For quick testing with Docker:
 ```bash
 # Start PostgreSQL
-docker run -d --name n8n-postgres -e POSTGRES_DB=n8n -e POSTGRES_USER=n8n -e POSTGRES_PASSWORD=n8npassword -p 5432:5432 postgres:15
+docker run -d --name n8n-postgres -e POSTGRES_DB=n8n -e POSTGRES_USER=n8n -e POSTGRES_PASSWORD=n8npassword -p 5432:5432 postgres:16
 
 # Start Redis
 docker run -d --name n8n-redis -p 6379:6379 redis:7-alpine

--- a/charts/n8n/examples/minimal-with-docker.yaml
+++ b/charts/n8n/examples/minimal-with-docker.yaml
@@ -3,7 +3,7 @@
 # Perfect for quick testing and development
 #
 # Prerequisites: Start external services with Docker
-# docker run -d --name n8n-postgres -e POSTGRES_DB=n8n -e POSTGRES_USER=n8n -e POSTGRES_PASSWORD=n8npassword -p 5432:5432 postgres:15
+# docker run -d --name n8n-postgres -e POSTGRES_DB=n8n -e POSTGRES_USER=n8n -e POSTGRES_PASSWORD=n8npassword -p 5432:5432 postgres:16
 # docker run -d --name n8n-redis -p 6379:6379 redis:7-alpine
 
 # Basic queue mode (minimum required)
@@ -85,7 +85,7 @@ serviceAccount:
 # Quick Setup Instructions:
 # 
 # 1. Start external services:
-#    docker run -d --name n8n-postgres -e POSTGRES_DB=n8n -e POSTGRES_USER=n8n -e POSTGRES_PASSWORD=n8npassword -p 5432:5432 postgres:15
+#    docker run -d --name n8n-postgres -e POSTGRES_DB=n8n -e POSTGRES_USER=n8n -e POSTGRES_PASSWORD=n8npassword -p 5432:5432 postgres:16
 #    docker run -d --name n8n-redis -p 6379:6379 redis:7-alpine
 #
 # 2. Create secrets:

--- a/charts/n8n/examples/minimal.yaml
+++ b/charts/n8n/examples/minimal.yaml
@@ -5,7 +5,7 @@
 # You must set up these services before deploying n8n
 # 
 # For quick testing, you can use Docker:
-# docker run -d --name postgres -e POSTGRES_DB=n8n -e POSTGRES_USER=n8n -e POSTGRES_PASSWORD=password -p 5432:5432 postgres:15
+# docker run -d --name postgres -e POSTGRES_DB=n8n -e POSTGRES_USER=n8n -e POSTGRES_PASSWORD=password -p 5432:5432 postgres:16
 # docker run -d --name redis -p 6379:6379 redis:7-alpine
 #
 # Use this as a starting point for development or testing

--- a/docker-compose/withPostgresAndWorker/docker-compose.yml
+++ b/docker-compose/withPostgresAndWorker/docker-compose.yml
@@ -55,7 +55,7 @@ services:
       retries: 10
 
   redis:
-    image: redis:6-alpine
+    image: redis:7-alpine
     restart: always
     volumes:
       - redis_storage:/data

--- a/kubernetes/postgres-deployment.yaml
+++ b/kubernetes/postgres-deployment.yaml
@@ -21,7 +21,7 @@ spec:
         service: postgres-n8n
     spec:
       containers:
-        - image: postgres:18
+        - image: postgres:16
           name: postgres
           resources:
             limits:


### PR DESCRIPTION
Fixes #163 — it wasn't clear which PostgreSQL / Redis / Valkey versions are supported for self-hosted n8n, and the examples didn't agree with each other (Postgres pinned at 15, 16, and 18 in different places; Redis at 6 vs 7).

**What this does:**
- Adds a **Requirements & supported versions** table near the top of the README — n8n, PostgreSQL, SQLite, MySQL/MariaDB (deprecated), Redis, and Valkey — with links to the canonical n8n docs. n8n doesn't publish a per-release matrix (its policy is "actively-maintained versions"), so the table says that plainly and points at the source of truth rather than inventing numbers.
- Reconciles the example image tags: everything now uses `postgres:16` and `redis:7-alpine` (Redis 6 is EOL). Also drops the stale `--version 1.0.0` from the helm quickstart, since it was already 9 minors behind `Chart.yaml`.

**Deliberately left alone:** the AWS ElastiCache block stays unpinned — pinning its version means also aligning the version-specific `RedisParamGroup` family, which risks breaking the CloudFormation template for no doc-clarity win. AWS RDS was already on 16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)