### PR TITLE
feat(chart): add hostAliases support to main, worker, and webhook-processor pods

### DIFF
--- a/charts/n8n/templates/deployment-main.yaml
+++ b/charts/n8n/templates/deployment-main.yaml
@@ -38,6 +38,11 @@ spec:
       automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       {{- end }}
 
+      {{- with .Values.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
       {{- if .Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}

--- a/charts/n8n/templates/deployment-webhook-processor.yaml
+++ b/charts/n8n/templates/deployment-webhook-processor.yaml
@@ -34,6 +34,11 @@ spec:
       automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       {{- end }}
 
+      {{- with .Values.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
       {{- if .Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}

--- a/charts/n8n/templates/deployment-worker.yaml
+++ b/charts/n8n/templates/deployment-worker.yaml
@@ -34,6 +34,11 @@ spec:
       automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       {{- end }}
 
+      {{- with .Values.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
       {{- if .Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}

--- a/charts/n8n/values.schema.json
+++ b/charts/n8n/values.schema.json
@@ -323,6 +323,20 @@
         }
       }
     },
+    "hostAliases": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "ip": { "type": "string" },
+          "hostnames": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        },
+        "required": ["ip", "hostnames"]
+      }
+    },
     "podAnnotations": { "type": "object", "additionalProperties": true },
     "podLabels": {
       "type": "object",

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -336,6 +336,18 @@ nodePlacement: {}
 #         value: n8n-workers
 #         effect: NoSchedule
 
+# ----- Host aliases -----
+# Adds entries to /etc/hosts on every pod (main, worker, webhook-processor).
+# Useful for pinning n8n's own public hostname (WEBHOOK_URL/N8N_HOST) to an
+# internal/private IP so that traffic n8n's own OAuth/MCP clients send to
+# themselves stays inside the cluster instead of hairpinning out through an
+# external load balancer or tunnel and back in.
+# hostAliases:
+#   - ip: "10.0.0.1"
+#     hostnames:
+#       - "n8n.example.com"
+hostAliases: []
+
 # ----- Security -----
 # Note: readOnlyRootFilesystem is intentionally not set. n8n writes to
 # ~/.n8n/, /tmp/, and other paths at runtime. Enabling it would require


### PR DESCRIPTION
## Summary

Adds an optional `hostAliases` values.yaml key that's templated into `/etc/hosts` on all three pod types (`main`, `worker`, `webhook-processor`), following the same `{{- with .Values.X }}` pattern already used for `nodeSelector`/`tolerations`/`affinity`.

## Motivation

When self-hosting n8n behind a tunnel/reverse-proxy setup (e.g. Cloudflare Tunnel, or a private-network SaaS connector), n8n's own outbound requests to its **own public hostname** (`N8N_HOST`/`WEBHOOK_URL`) — for example the MCP OAuth server's discovery/token endpoints, which n8n's own OAuth client and third-party MCP clients hit at that public FQDN — have to leave the cluster/VPC and hairpin back in through the external ingress path. This can break in setups where:

- The tunnel/proxy actively disallows loopback ("hairpin") traffic, or
- The client hitting `WEBHOOK_URL` needs a same-Host-header request served entirely inside the private network for latency/security reasons.

`hostAliases` lets operators pin the pod's own public hostname directly to an internal ClusterIP/private IP so this traffic never leaves the cluster, without needing external DNS changes.

## Changes

- `charts/n8n/templates/deployment-main.yaml`, `deployment-worker.yaml`, `deployment-webhook-processor.yaml`: render `spec.hostAliases` from `.Values.hostAliases` when set (no-op otherwise).
- `charts/n8n/values.yaml`: new `hostAliases: []` default with documentation comment and example.
- `charts/n8n/values.schema.json`: schema for the new key.

## Test plan

- [x] `helm lint charts/n8n` passes.
- [x] `helm template` with `hostAliases` set renders correctly on `main`, `worker` (queue mode), and `webhook-processor` pods.
- [x] `helm template` with default values (no `hostAliases`) produces no `hostAliases` key in any pod spec — fully backward compatible.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional `hostAliases` to the Helm chart to inject `/etc/hosts` entries for the `main`, `worker`, and `webhook-processor` pods. This lets pods resolve n8n’s public hostname to an internal IP to avoid hairpinning through external ingress or tunnels.

- **New Features**
  - Adds `.Values.hostAliases` (default `[]`, schema-validated) with docs in `values.yaml`.
  - Renders `spec.hostAliases` in all three deployments when set; no-op when unset.

<sup>Written for commit c3ef66dd6306ec44cf554ebbeda9cbc779b4dfd8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-hosting/pull/167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

