### PR TITLE
chore(docker): migrate compose configuration to v2

### DIFF
--- a/docker-caddy/docker-compose.yml
+++ b/docker-caddy/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   caddy:
     image: caddy:latest

--- a/docker-compose/subfolderWithSSL/README.md
+++ b/docker-compose/subfolderWithSSL/README.md
@@ -10,11 +10,11 @@ command in the current folder.
 **IMPORTANT:** But before you do that change the default users and passwords in the `.env` file!
 
 ```
-docker-compose up -d
+docker compose up -d
 ```
 
 To stop it execute:
 
 ```
-docker-compose stop
+docker compose stop
 ```

--- a/docker-compose/subfolderWithSSL/docker-compose.yml
+++ b/docker-compose/subfolderWithSSL/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   traefik:
     image: 'traefik'

--- a/docker-compose/withPostgres/README.md
+++ b/docker-compose/withPostgres/README.md
@@ -10,13 +10,13 @@ command in the current folder.
 **IMPORTANT:** But before you do that change the default users and passwords in the [`.env`](.env) file!
 
 ```
-docker-compose up -d
+docker compose up -d
 ```
 
 To stop it execute:
 
 ```
-docker-compose stop
+docker compose stop
 ```
 
 ## Configuration

--- a/docker-compose/withPostgres/docker-compose.yml
+++ b/docker-compose/withPostgres/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 volumes:
   db_storage:
   n8n_storage:


### PR DESCRIPTION
# Pull Request

## Description
Migrate docker compose configuration to Compose V2
## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Related Issues
Fixes # (issue)
Relates to # (issue)

## Changes Made
- migrated docker compose configurations to compose v2
- updated documentation for docker compose setup

### Deployment Testing (if applicable)
- [x] Tested with compose v2
### Specific Testing for Changes
Describe any specific testing you performed for your changes:
- docker compose up -d (with compose v2)


## Documentation Updates
- [x] Updated README.md (if needed)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] All new and existing tests pass

## Additional Notes
traefik version is not specified in the subFolderwithSSL configuration. is it intended or is versioning required?


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated all Docker Compose configs to Compose V2 to align with the current Docker CLI. Removed deprecated top-level `version` keys (including in `docker-caddy`) and updated README commands to use `docker compose`, with no service changes.

<sup>Written for commit 0e49271c5d4dac31120a4f7429e3cf26be2a3c8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-hosting/pull/168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



