### PR TITLE
feat(chart): route /mcp to webhook processors

### DIFF
--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -75,7 +75,11 @@ For production, use an external secrets operator (e.g., [External Secrets Operat
 
 Set `ingress.enabled=true` to create the main Ingress for the n8n UI, API, and test webhooks. Configure `ingress.className`, controller-specific `ingress.annotations`, and `ingress.tls` for HTTPS termination. For cert-manager, add the issuer annotation and set `ingress.tls[].secretName` to the certificate Secret cert-manager should create.
 
-When `webhookProcessor.enabled=true`, enable `ingress.webhookProcessor.enabled` to create a second Ingress for production webhook traffic. The webhook processor Ingress routes `/webhook/`, `/webhook-waiting/`, `/form/`, and `/form-waiting/` to webhook processor pods. Test webhook paths such as `/webhook-test/` stay on the main Ingress.
+When `webhookProcessor.enabled=true`, enable `ingress.webhookProcessor.enabled` to create a second Ingress for production webhook traffic. The webhook processor Ingress routes `/webhook/`, `/webhook-waiting/`, `/form/`, `/form-waiting/`, and `/mcp/` to webhook processor pods. Test paths such as `/webhook-test/` and `/mcp-test/` stay on the main Ingress.
+
+### MCP Server Trigger with multiple webhook processors
+
+MCP Server Trigger endpoints (`/mcp/`) are served by the webhook processors, so scaling `webhookProcessor.replicaCount` (or its HPA/KEDA) scales MCP alongside regular webhooks — no dedicated single-replica pod or session affinity is required. This relies on n8n's queue-mode/multi-instance MCP support added in **n8n 2.8.0** ([n8n-io/n8n#25147](https://github.com/n8n-io/n8n/pull/25147)), which recreates MCP sessions from Redis and runs tool calls on workers.
 
 Use `ingress.sticky.enabled=true` for nginx cookie affinity, or `service.sessionAffinity.enabled=true` for Kubernetes `ClientIP` affinity. Multi-main deployments require sticky sessions at the load-balancing layer.
 

--- a/charts/n8n/examples/README.md
+++ b/charts/n8n/examples/README.md
@@ -17,6 +17,7 @@ This directory contains common configuration examples for different deployment s
 
 ### Community Examples (Ingress)
 - **[https-ingress.yaml](./https-ingress.yaml)** - HTTPS ingress with TLS, sticky sessions, and webhook processor routing
+- **[mcp-server.yaml](./mcp-server.yaml)** - Scale the MCP Server Trigger (`/mcp`) across multiple webhook processors (requires n8n ≥ 2.8.0)
 
 ### Community Examples (Node Placement)
 - **[node-placement.yaml](./node-placement.yaml)** - Pin `main` and webhook-processor to a stable node pool; run workers on an autoscaling pool

--- a/charts/n8n/examples/https-ingress.yaml
+++ b/charts/n8n/examples/https-ingress.yaml
@@ -37,9 +37,9 @@ webhookProcessor:
 webhook:
   url: "https://n8n.example.com"
 
-# Dedicated webhook ingress routes production webhook and form paths to
-# webhook-processor pods. Test webhook paths continue to route to the main
-# ingress through the catch-all "/" path above.
+# Dedicated webhook ingress routes production webhook, form, and MCP (/mcp)
+# paths to webhook-processor pods. Test paths (/webhook-test/, /mcp-test/)
+# continue to route to the main ingress through the catch-all "/" path above.
 ingress:
   enabled: true
   className: nginx

--- a/charts/n8n/examples/mcp-server.yaml
+++ b/charts/n8n/examples/mcp-server.yaml
@@ -1,0 +1,71 @@
+# Example: Scale the MCP Server Trigger across multiple webhook processors.
+#
+# n8n's MCP Server Trigger serves its endpoints under /mcp. The webhook
+# processor Ingress routes /mcp to the webhook-processor pods, so MCP scales
+# with `webhookProcessor.replicaCount` (or its HPA/KEDA) just like regular
+# webhook traffic — no dedicated single-replica pod or session affinity needed.
+#
+# REQUIRES n8n >= 2.8.0, which added MCP support in queue mode / across multiple
+# instances (MCP sessions are recreated from Redis, tool calls run on workers).
+# See https://github.com/n8n-io/n8n/pull/25147
+#
+# Prerequisites:
+# - An ingress controller installed in the cluster.
+# - External PostgreSQL and Redis services for queue mode.
+
+image:
+  # Must be >= 2.8.0 for multi-instance MCP. "stable" (current 2.x) satisfies this.
+  tag: "stable"
+
+secretRefs:
+  existingSecret: "n8n-core-secrets"
+
+database:
+  useExternal: true
+  host: "postgres.example.internal"
+  passwordSecret:
+    name: "n8n-db-secret"
+    key: "password"
+
+redis:
+  enabled: true
+  useExternal: true
+  host: "redis.example.internal"
+  passwordSecret:
+    name: "n8n-redis-secret"
+    key: "password"
+
+queueMode:
+  enabled: true
+  workerReplicaCount: 2
+  workerConcurrency: 10
+
+# Multiple webhook processors serving /webhook, /form, and /mcp. Scale freely.
+webhookProcessor:
+  enabled: true
+  replicaCount: 3
+  disableProductionWebhooksOnMainProcess: true
+
+webhook:
+  url: "https://n8n.example.com"
+
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: n8n.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  # Dedicated ingress routes /webhook, /webhook-waiting, /form, /form-waiting,
+  # and /mcp to the webhook-processor pods.
+  webhookProcessor:
+    enabled: true
+    className: nginx
+    # MCP uses long-lived SSE / streamable-HTTP connections. On nginx, disable
+    # response buffering and raise the proxy timeouts so streamed events flow.
+    annotations:
+      nginx.ingress.kubernetes.io/proxy-buffering: "off"
+      nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
+      nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+      nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"

--- a/charts/n8n/templates/ingress-webhook.yaml
+++ b/charts/n8n/templates/ingress-webhook.yaml
@@ -49,6 +49,13 @@ spec:
                 name: {{ include "n8n.fullname" $ }}-webhook-processor
                 port:
                   number: {{ $.Values.service.port }}
+          - path: /mcp/
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "n8n.fullname" $ }}-webhook-processor
+                port:
+                  number: {{ $.Values.service.port }}
   {{- end }}
   {{- with (.Values.ingress.webhookProcessor).tls }}
   tls:


### PR DESCRIPTION
## What

Adds `/mcp/` to the webhook processor Ingress so the MCP Server Trigger works when you run more than one webhook processor.

## Why

A customer asked whether the chart could support multiple webhook processors with MCP — today you're effectively stuck at one. It turns out the real limitation was already fixed upstream: n8n 2.8.0 (n8n-io/n8n#25147) added MCP support in queue mode and across multiple instances — MCP sessions are recreated from Redis and tool calls are offloaded to workers. So MCP already scales across webhook processors at the n8n layer.

The only thing missing on the chart side was the routing. The webhook Ingress sent `/webhook`, `/form` (and their `-waiting` variants) to the webhook processors, but not `/mcp`. So `/mcp` fell through to the main Ingress, and since production webhooks are disabled on main when webhook processors are enabled, it 404'd. This just adds the missing route — no new values, no new pods, one Ingress path.

## Testing

Verified end-to-end on a local OrbStack cluster with n8n 2.30.6:
- queue mode, `webhookProcessor.replicaCount=3`, no session affinity
- an active MCP Server Trigger workflow (Calculator + JS Code tool)
- drove `/mcp` with a streamable-HTTP MCP client, fresh connection per request so kube-proxy spread calls across all 3 replicas
- 60/60 tool calls succeeded across all replicas with correct results, no hangs (the old Code-node hang is also gone on 2.8.0+)
- through a real nginx ingress: `/mcp` → webhook processor works; hitting main directly at `/mcp` returns 404, confirming the route was the missing piece

Requires n8n ≥ 2.8.0, documented in the README and the new example.

## Changes
- `templates/ingress-webhook.yaml`: route `/mcp/` to the webhook processor service
- `README.md`: document `/mcp` routing + a short MCP-scaling section
- `examples/mcp-server.yaml`: new example (3 webhook processors + `/mcp` ingress + SSE nginx annotations)
- `examples/README.md`, `examples/https-ingress.yaml`: index entry + comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route `/mcp` to the webhook processor Ingress so the MCP Server Trigger works and scales across multiple webhook processors. Fixes 404s when processors are enabled by sending MCP traffic to the right service.

- **New Features**
  - Add `/mcp/` path to the webhook-processor Ingress.
  - Document MCP routing and scaling in the README.
  - Add `examples/mcp-server.yaml` (3 processors + nginx SSE annotations); update examples index and HTTPS ingress comments.

- **Migration**
  - Requires n8n ≥ 2.8.0 for multi-instance MCP. No new values or pods.

<sup>Written for commit eac4ead924a7a0417d9ac212e4153e06530136a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-hosting/pull/171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

