### PR TITLE
fix(chart): use correct Bull queue key bull:jobs:wait in KEDA examples

### DIFF
--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -227,7 +227,7 @@ keda:
     triggers:
       - type: redis
         metadata:
-          listName: "bull:default:wait"
+          listName: "bull:jobs:wait"
           listLength: "5"
 ```
 

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -231,6 +231,8 @@ keda:
           listLength: "5"
 ```
 
+The `listName` is the Bull waiting-list key, `<prefix>:jobs:wait`, where the prefix defaults to `bull`. If you set `redis.prefix`, update `listName` to match (e.g. `myprefix:jobs:wait`), otherwise the scaler polls a key n8n never writes to and queue-depth autoscaling won't fire.
+
 See [keda-autoscaling.yaml](./examples/keda-autoscaling.yaml) for a complete example.
 
 ## Upgrading

--- a/charts/n8n/examples/keda-autoscaling.yaml
+++ b/charts/n8n/examples/keda-autoscaling.yaml
@@ -32,7 +32,7 @@ keda:
           # Leave empty to auto-derive from redis.host:redis.port
           address: ""
           # Bull queue key for waiting jobs
-          listName: "bull:default:wait"
+          listName: "bull:jobs:wait"
           # Scale up when queue length exceeds 5 per replica
           listLength: "5"
         authenticationRef:

--- a/charts/n8n/examples/keda-autoscaling.yaml
+++ b/charts/n8n/examples/keda-autoscaling.yaml
@@ -31,7 +31,8 @@ keda:
         metadata:
           # Leave empty to auto-derive from redis.host:redis.port
           address: ""
-          # Bull queue key for waiting jobs
+          # Bull queue key for waiting jobs: "<prefix>:jobs:wait" (prefix defaults
+          # to "bull"). If you set redis.prefix, update this to "<prefix>:jobs:wait".
           listName: "bull:jobs:wait"
           # Scale up when queue length exceeds 5 per replica
           listLength: "5"

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -501,7 +501,7 @@ keda:
           # Redis address (auto-derived from redis.host:redis.port if empty)
           address: ""
           # Bull queue waiting list key
-          listName: "bull:default:wait"
+          listName: "bull:jobs:wait"
           # Target queue length per worker replica
           listLength: "5"
         authenticationRef:

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -500,7 +500,8 @@ keda:
         metadata:
           # Redis address (auto-derived from redis.host:redis.port if empty)
           address: ""
-          # Bull queue waiting list key
+          # Bull queue waiting list key: "<prefix>:jobs:wait" (prefix defaults to
+          # "bull"). If you set redis.prefix, update this to match, e.g. "myprefix:jobs:wait".
           listName: "bull:jobs:wait"
           # Target queue length per worker replica
           listLength: "5"
@@ -638,7 +639,7 @@ redis:
   # Advanced Redis settings
   database: 0                                      # <-- Redis database number
   timeout: 10000                                   # <-- Redis timeout threshold (ms)
-  prefix: ""                                       # <-- Queue key prefix
+  prefix: ""                                       # <-- Queue key prefix (if set, update keda.worker.triggers listName to "<prefix>:jobs:wait")
   tls: false                                       # <-- Enable TLS (required for AWS ElastiCache and other managed Redis services)
   dualstack: false                                 # <-- Enable dual-stack (IPv4/IPv6)
   # Redis Cluster support (comma-separated list of host:port)


### PR DESCRIPTION
## What

The KEDA autoscaling examples pointed the Redis-list scaler at `bull:default:wait`, but n8n names its Bull queue `jobs`, not `default`. Bull composes keys as `<prefix>:<queueName>:<state>`, so the waiting-list key is `bull:jobs:wait`.

As written, `LLEN bull:default:wait` always returns 0, so queue-depth autoscaling never fires — the ScaledObject silently falls back to whatever other triggers are configured.

## Why `bull:jobs:wait`

From n8n source (n8n-io/n8n):
- `packages/cli/src/scaling/constants.ts` — `export const QUEUE_NAME = 'jobs';`
- `packages/cli/src/scaling/scaling.service.ts` — `new BullQueue(QUEUE_NAME, { prefix, ... })`
- `packages/@n8n/config/src/configs/scaling-mode.config.ts` — default prefix `bull` (docstring `@example 'bull:jobs:23'`)

The prefix is still overridable via `QUEUE_BULL_PREFIX`. This matches the correct key already used by the #169 ECS Fargate Lambda — this is the chart side of the same key.

## Changes

Find/replace `bull:default:wait` → `bull:jobs:wait` (one occurrence each):
- `charts/n8n/values.yaml`
- `charts/n8n/examples/keda-autoscaling.yaml`
- `charts/n8n/README.md`

`helm lint charts/n8n` passes.

Fixes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Point the KEDA Redis-list scaler to the correct Bull key `bull:jobs:wait` so queue-length autoscaling works with n8n’s `jobs` queue. Clarifies that `listName` must be `<prefix>:jobs:wait` (prefix defaults to `bull`) and must stay in sync with `redis.prefix` to avoid missed scaling.

<sup>Written for commit ce6b743a102759474f48700e12a00e20fa04d4db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-hosting/pull/174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

