### PR TITLE
fix(chart): use DB_POSTGRESDB_SSL_ENABLED to enable Postgres TLS

### DIFF
--- a/charts/n8n/templates/_configmap-env.tpl
+++ b/charts/n8n/templates/_configmap-env.tpl
@@ -42,11 +42,11 @@ Environment variables from ConfigMap for all components
       key: DB_POSTGRESDB_SCHEMA
 {{- end }}
 {{- if .Values.database.ssl.enabled }}
-- name: DB_POSTGRESDB_SSL
+- name: DB_POSTGRESDB_SSL_ENABLED
   valueFrom:
     configMapKeyRef:
       name: {{ include "n8n.fullname" . }}
-      key: DB_POSTGRESDB_SSL
+      key: DB_POSTGRESDB_SSL_ENABLED
 {{- if .Values.database.ssl.ca }}
 - name: DB_POSTGRESDB_SSL_CA
   valueFrom:

--- a/charts/n8n/templates/configmap.yaml
+++ b/charts/n8n/templates/configmap.yaml
@@ -24,7 +24,7 @@ data:
   DB_POSTGRESDB_SCHEMA: {{ .Values.database.schema | quote }}
   {{- end }}
   {{- if .Values.database.ssl.enabled }}
-  DB_POSTGRESDB_SSL: "true"
+  DB_POSTGRESDB_SSL_ENABLED: "true"
   {{- if .Values.database.ssl.ca }}
   DB_POSTGRESDB_SSL_CA: {{ .Values.database.ssl.ca | quote }}
   {{- end }}


### PR DESCRIPTION
# Pull Request

## Description
n8n reads DB_POSTGRESDB_SSL_ENABLED, not DB_POSTGRESDB_SSL, so database.ssl.enabled had no effect on its own and the connection quietly stayed plaintext.

This likely went unnoticed because n8n also switches SSL on whenever DB_POSTGRESDB_SSL_CA or _CERT is set, and the chart emits those correctly.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made
- Renamed the ConfigMap key in configmap.yaml and the env var referencing it in _configmap-env.tpl from DB_POSTGRESDB_SSL to DB_POSTGRESDB_SSL_ENABLED.

## Testing Performed
Rendered with database.ssl.enabled=true and no client certs. Before no SSL variable n8n reads was emitted. With the change: DB_POSTGRESDB_SSL_ENABLED=true is present in the ConfigMap and injected into main, worker and webhook-processor.

### Chart Validation
- [x] `helm lint charts/n8n` passes
**- [ ] `./scripts/validate-examples.sh` passes** -> this doesn't exist
- [x] Template rendering works with all examples

## Breaking Changes
`database.ssl.enabled` keeps its name and meaning, and `DB_POSTGRESDB_SSL` is not read by n8n, so no working configuration depends on it. Deployments already getting TLS via `ssl.ca`/`ssl.cert` are unaffected but those that were silently running plaintext will now genuinely negotiate TLS on upgrade.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added examples that demonstrate the changes (if applicable)
- [x] All new and existing tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Postgres TLS enablement in the `n8n` chart by emitting `DB_POSTGRESDB_SSL_ENABLED` when `database.ssl.enabled=true`. Instances that were silently using plaintext will now negotiate TLS as expected.

- **Bug Fixes**
  - Renamed ConfigMap key and env var from `DB_POSTGRESDB_SSL` to `DB_POSTGRESDB_SSL_ENABLED` in `configmap.yaml` and `_configmap-env.tpl`.
  - Verified rendering: `DB_POSTGRESDB_SSL_ENABLED=true` is injected into main, worker, and webhook-processor; `helm lint` passes.

<sup>Written for commit 5e74d7927bdbcf5a98f66b6731a0d3ee54696bc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-hosting/pull/175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

