### PR TITLE
Updated scaledobject-worker to allow pausing to drain jobs during n8n…

### DIFF
--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -99,6 +99,7 @@ To use the namespace's default ServiceAccount, set `name: ""`. If you set `creat
 | `hpa.main.enabled` | HPA for main pods | `false` |
 | `hpa.worker.enabled` | HPA for worker pods | `false` |
 | `keda.enabled` | KEDA queue-based autoscaling | `false` |
+| `keda.worker.pause` | Pause worker autoscaling and scale to zero | `false` |
 | `networkPolicy.enabled` | Network policies | `false` |
 
 See [values.yaml](./values.yaml) for the full list of configurable values.
@@ -132,6 +133,8 @@ The built-in HPA scales workers based on CPU utilization. For queue-based worklo
 
 When `keda.enabled` is true, the chart creates KEDA `ScaledObject` resources instead of built-in HPAs for workers (and optionally webhook processors). KEDA must be installed in the cluster.
 
+Set `keda.worker.pause: true` to pause worker autoscaling and scale workers to zero (sets the `autoscaling.keda.sh/paused` and `autoscaling.keda.sh/paused-replicas: "0"` annotations on the ScaledObject).
+
 ```bash
 # Install KEDA
 helm install keda kedacore/keda --namespace keda-system --create-namespace
@@ -141,6 +144,7 @@ helm install keda kedacore/keda --namespace keda-system --create-namespace
 keda:
   enabled: true
   worker:
+    pause: false              # Set true to scale workers to zero and pause KEDA
     minReplicaCount: 2
     maxReplicaCount: 20
     triggers:

--- a/charts/n8n/examples/keda-autoscaling.yaml
+++ b/charts/n8n/examples/keda-autoscaling.yaml
@@ -22,6 +22,9 @@ hpa:
 keda:
   enabled: true
   worker:
+    # Pause autoscaling and scale workers to zero
+    # Sets autoscaling.keda.sh/paused=true and autoscaling.keda.sh/paused-replicas=0
+    pause: false
     pollingInterval: 15       # How often KEDA checks the queue (seconds)
     cooldownPeriod: 300        # Wait time before scaling down (seconds)
     minReplicaCount: 2

--- a/charts/n8n/templates/scaledobject-worker.yaml
+++ b/charts/n8n/templates/scaledobject-worker.yaml
@@ -7,11 +7,6 @@ metadata:
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
     app.kubernetes.io/component: worker
-  {{- if .Values.keda.worker.pause }}
-  annotations:
-    autoscaling.keda.sh/paused: "true"
-    autoscaling.keda.sh/paused-replicas: "0"
-  {{- end }}
 spec:
   scaleTargetRef:
     name: {{ include "n8n.fullname" . }}-worker

--- a/charts/n8n/templates/scaledobject-worker.yaml
+++ b/charts/n8n/templates/scaledobject-worker.yaml
@@ -7,6 +7,11 @@ metadata:
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
     app.kubernetes.io/component: worker
+  {{- if .Values.keda.worker.pause }}
+  annotations:
+    autoscaling.keda.sh/paused: "true"
+    autoscaling.keda.sh/paused-replicas: "0"
+  {{- end }}
 spec:
   scaleTargetRef:
     name: {{ include "n8n.fullname" . }}-worker

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -379,6 +379,9 @@ hpa:
 keda:
   enabled: false
   worker:
+    # Pause KEDA autoscaling and scale workers to zero
+    # Sets autoscaling.keda.sh/paused=true and autoscaling.keda.sh/paused-replicas=0
+    pause: false
     pollingInterval: 15
     cooldownPeriod: 300
     minReplicaCount: 2


### PR DESCRIPTION
# Pull Request

## Description
Adds a `keda.worker.pause` setting to the n8n Helm chart so worker KEDA autoscaling can be paused and workers scaled to zero via ScaledObject annotations.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Example/configuration update
- [ ] CI/CD improvements

## Related Issues
Fixes # N/A
Relates to # N/A

## Changes Made
- Added `keda.worker.pause` (`true`/`false`, default `false`) to control KEDA worker autoscaling pause behavior
- When `pause` is `true`, the worker ScaledObject sets `autoscaling.keda.sh/paused: "true"` and `autoscaling.keda.sh/paused-replicas: "0"` to scale workers to zero and pause autoscaling
- Updated README and the KEDA autoscaling example to document the new setting

## Testing Performed
- Rendered the worker ScaledObject with `keda.worker.pause` enabled and disabled

### Chart Validation
- [ ] `helm lint charts/n8n` passes
- [ ] `./scripts/validate-examples.sh` passes
- [x] Template rendering works with all examples

### Deployment Testing (if applicable)
- [x] Tested with minimal configuration
- [ ] Tested with production configuration
- [ ] Tested upgrade path from previous version
- [ ] All pods start successfully
- [ ] Application is accessible

### Specific Testing for Changes
Describe any specific testing you performed for your changes:
- Rendered the chart with `keda.enabled=true` and `keda.worker.pause=false` to confirm pause annotations are omitted.
- Rendered the chart with `keda.worker.pause=true` to confirm both `autoscaling.keda.sh/paused: "true"` and `autoscaling.keda.sh/paused-replicas: "0"` are set on the worker ScaledObject.

## Breaking Changes
If this includes breaking changes, describe what they are and provide migration instructions:
- None. The new setting defaults to `false`, so existing KEDA worker ScaledObjects continue to behave as before.

## Documentation Updates
- [ ] Updated Chart.yaml version (if needed)
- [ ] Updated CHANGELOG.md
- [x] Updated README.md (if needed)
- [x] Updated examples (if needed)
- [ ] Updated CONTRIBUTING.md (if needed)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [x] I have added examples that demonstrate the changes (if applicable)
- [ ] All new and existing tests pass

## Screenshots (if applicable)
Not applicable.

## Additional Notes
This change is backward compatible because `keda.worker.pause` defaults to `false` and only adds pause annotations when explicitly enabled.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `keda.worker.pause` option to the `n8n` Helm chart to pause KEDA worker autoscaling and scale workers to zero so jobs can drain during upgrades. Defaults to `false`, so existing installs are unaffected.

- **New Features**
  - When `keda.worker.pause: true`, sets `autoscaling.keda.sh/paused: "true"` and `autoscaling.keda.sh/paused-replicas: "0"` on the worker ScaledObject.
  - Documented in `README.md`, `values.yaml`, and `examples/keda-autoscaling.yaml`.

<sup>Written for commit 984937827a897308d8d594f91b344b6815bc7fb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-hosting/pull/176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


