### PR TITLE
feat(chart): Allow workers to be paused and scaled to zero

### DIFF
--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -134,6 +134,7 @@ To use the namespace's default ServiceAccount, set `name: ""`. If you set `creat
 | `hpa.main.enabled` | HPA for main pods | `false` |
 | `hpa.worker.enabled` | HPA for worker pods | `false` |
 | `keda.enabled` | KEDA queue-based autoscaling | `false` |
+| `keda.worker.pause` | Pause worker autoscaling and scale workers to zero | `false` |
 | `networkPolicy.enabled` | Network policies | `false` |
 | `extraContainers` | Additional sidecar containers on main, worker, and webhook-processor pods | `[]` |
 | `nodePlacement` | Component-specific node placement overrides | `{}` |
@@ -222,6 +223,7 @@ helm install keda kedacore/keda --namespace keda-system --create-namespace
 keda:
   enabled: true
   worker:
+    pause: false
     minReplicaCount: 2
     maxReplicaCount: 20
     triggers:
@@ -230,6 +232,8 @@ keda:
           listName: "bull:jobs:wait"
           listLength: "5"
 ```
+
+Set `keda.worker.pause: true` to scale workers to zero and pause autoscaling. This adds the `autoscaling.keda.sh/paused: "true"` and `autoscaling.keda.sh/paused-replicas: "0"` annotations to the worker ScaledObject.
 
 The `listName` is the Bull waiting-list key, `<prefix>:jobs:wait`, where the prefix defaults to `bull`. If you set `redis.prefix`, update `listName` to match (e.g. `myprefix:jobs:wait`), otherwise the scaler polls a key n8n never writes to and queue-depth autoscaling won't fire.
 

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -134,7 +134,8 @@ To use the namespace's default ServiceAccount, set `name: ""`. If you set `creat
 | `hpa.main.enabled` | HPA for main pods | `false` |
 | `hpa.worker.enabled` | HPA for worker pods | `false` |
 | `keda.enabled` | KEDA queue-based autoscaling | `false` |
-| `keda.worker.pause` | Pause worker autoscaling and scale workers to zero | `false` |
+| `keda.worker.pause` | Pause worker KEDA autoscaling | `false` |
+| `keda.worker.pausedReplicaCount` | Worker replica count while paused (`autoscaling.keda.sh/paused-replicas`); only when `pause=true` | `0` |
 | `networkPolicy.enabled` | Network policies | `false` |
 | `extraContainers` | Additional sidecar containers on main, worker, and webhook-processor pods | `[]` |
 | `nodePlacement` | Component-specific node placement overrides | `{}` |
@@ -233,7 +234,14 @@ keda:
           listLength: "5"
 ```
 
-Set `keda.worker.pause: true` to scale workers to zero and pause autoscaling. This adds the `autoscaling.keda.sh/paused: "true"` and `autoscaling.keda.sh/paused-replicas: "0"` annotations to the worker ScaledObject.
+Set `keda.worker.pause: true` to pause worker autoscaling. This adds `autoscaling.keda.sh/paused: "true"` to the worker ScaledObject. By default, workers scale to zero (`pausedReplicaCount: 0`). To pause autoscaling while keeping the current replica count (for example while troubleshooting a scaling issue), set `pausedReplicaCount` to the desired count:
+
+```yaml
+keda:
+  worker:
+    pause: true
+    pausedReplicaCount: 5
+```
 
 The `listName` is the Bull waiting-list key, `<prefix>:jobs:wait`, where the prefix defaults to `bull`. If you set `redis.prefix`, update `listName` to match (e.g. `myprefix:jobs:wait`), otherwise the scaler polls a key n8n never writes to and queue-depth autoscaling won't fire.
 

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -134,8 +134,8 @@ To use the namespace's default ServiceAccount, set `name: ""`. If you set `creat
 | `hpa.main.enabled` | HPA for main pods | `false` |
 | `hpa.worker.enabled` | HPA for worker pods | `false` |
 | `keda.enabled` | KEDA queue-based autoscaling | `false` |
-| `keda.worker.pause` | Pause worker KEDA autoscaling | `false` |
-| `keda.worker.pausedReplicaCount` | Worker replica count while paused (`autoscaling.keda.sh/paused-replicas`); only when `pause=true` | `0` |
+| `keda.worker.pause` | Pause worker autoscaling, freezing workers at their current replica count | `false` |
+| `keda.worker.pausedReplicaCount` | Optional replica count to hold whilst paused; only applied when `pause=true` | `null` |
 | `networkPolicy.enabled` | Network policies | `false` |
 | `extraContainers` | Additional sidecar containers on main, worker, and webhook-processor pods | `[]` |
 | `nodePlacement` | Component-specific node placement overrides | `{}` |
@@ -234,14 +234,18 @@ keda:
           listLength: "5"
 ```
 
-Set `keda.worker.pause: true` to pause worker autoscaling. This adds `autoscaling.keda.sh/paused: "true"` to the worker ScaledObject. By default, workers scale to zero (`pausedReplicaCount: 0`). To pause autoscaling while keeping the current replica count (for example while troubleshooting a scaling issue), set `pausedReplicaCount` to the desired count:
+Set `keda.worker.pause: true` to pause worker autoscaling. This adds `autoscaling.keda.sh/paused: "true"` to the worker ScaledObject, and KEDA holds the workers at whatever replica count they are currently running, which is what you want whilst troubleshooting a scaling issue.
+
+To pause and hold a specific count instead, set `pausedReplicaCount`. Setting it to `0` scales workers down entirely:
 
 ```yaml
 keda:
   worker:
     pause: true
-    pausedReplicaCount: 5
+    pausedReplicaCount: 0
 ```
+
+`pausedReplicaCount` is only applied when `pause: true`, and leaving it unset is what gives you the freeze-at-current behaviour. With both annotations set KEDA scales the workers to the count first, then pauses autoscaling.
 
 The `listName` is the Bull waiting-list key, `<prefix>:jobs:wait`, where the prefix defaults to `bull`. If you set `redis.prefix`, update `listName` to match (e.g. `myprefix:jobs:wait`), otherwise the scaler polls a key n8n never writes to and queue-depth autoscaling won't fire.
 

--- a/charts/n8n/examples/keda-autoscaling.yaml
+++ b/charts/n8n/examples/keda-autoscaling.yaml
@@ -22,6 +22,8 @@ hpa:
 keda:
   enabled: true
   worker:
+    # Pause autoscaling and scale workers to zero
+    pause: false
     pollingInterval: 15       # How often KEDA checks the queue (seconds)
     cooldownPeriod: 300        # Wait time before scaling down (seconds)
     minReplicaCount: 2

--- a/charts/n8n/examples/keda-autoscaling.yaml
+++ b/charts/n8n/examples/keda-autoscaling.yaml
@@ -22,8 +22,9 @@ hpa:
 keda:
   enabled: true
   worker:
-    # Pause autoscaling and scale workers to zero
+    # Pause autoscaling (scale to zero by default, or set pausedReplicaCount to freeze at a specific count)
     pause: false
+    pausedReplicaCount: 0
     pollingInterval: 15       # How often KEDA checks the queue (seconds)
     cooldownPeriod: 300        # Wait time before scaling down (seconds)
     minReplicaCount: 2

--- a/charts/n8n/examples/keda-autoscaling.yaml
+++ b/charts/n8n/examples/keda-autoscaling.yaml
@@ -22,9 +22,10 @@ hpa:
 keda:
   enabled: true
   worker:
-    # Pause autoscaling (scale to zero by default, or set pausedReplicaCount to freeze at a specific count)
+    # Pause autoscaling, holding workers at their current replica count
     pause: false
-    pausedReplicaCount: 0
+    # Uncomment to pause at a specific count instead; 0 scales workers down entirely
+    # pausedReplicaCount: 0
     pollingInterval: 15       # How often KEDA checks the queue (seconds)
     cooldownPeriod: 300        # Wait time before scaling down (seconds)
     minReplicaCount: 2

--- a/charts/n8n/templates/scaledobject-worker.yaml
+++ b/charts/n8n/templates/scaledobject-worker.yaml
@@ -12,7 +12,7 @@ metadata:
     {{- $annotations := deepCopy (.Values.commonAnnotations | default dict) }}
     {{- if .Values.keda.worker.pause }}
     {{- $_ := set $annotations "autoscaling.keda.sh/paused" "true" }}
-    {{- $_ := set $annotations "autoscaling.keda.sh/paused-replicas" "0" }}
+    {{- $_ := set $annotations "autoscaling.keda.sh/paused-replicas" (.Values.keda.worker.pausedReplicaCount | toString) }}
     {{- end }}
     {{- toYaml $annotations | nindent 4 }}
   {{- end }}

--- a/charts/n8n/templates/scaledobject-worker.yaml
+++ b/charts/n8n/templates/scaledobject-worker.yaml
@@ -12,7 +12,9 @@ metadata:
     {{- $annotations := deepCopy (.Values.commonAnnotations | default dict) }}
     {{- if .Values.keda.worker.pause }}
     {{- $_ := set $annotations "autoscaling.keda.sh/paused" "true" }}
+    {{- if not (kindIs "invalid" .Values.keda.worker.pausedReplicaCount) }}
     {{- $_ := set $annotations "autoscaling.keda.sh/paused-replicas" (.Values.keda.worker.pausedReplicaCount | toString) }}
+    {{- end }}
     {{- end }}
     {{- toYaml $annotations | nindent 4 }}
   {{- end }}

--- a/charts/n8n/templates/scaledobject-worker.yaml
+++ b/charts/n8n/templates/scaledobject-worker.yaml
@@ -7,9 +7,15 @@ metadata:
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
     app.kubernetes.io/component: worker
-  {{- with .Values.commonAnnotations }}
+  {{- if or .Values.commonAnnotations .Values.keda.worker.pause }}
   annotations:
+    {{- with .Values.commonAnnotations }}
     {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- if .Values.keda.worker.pause }}
+    autoscaling.keda.sh/paused: "true"
+    autoscaling.keda.sh/paused-replicas: "0"
+    {{- end }}
   {{- end }}
 spec:
   scaleTargetRef:

--- a/charts/n8n/templates/scaledobject-worker.yaml
+++ b/charts/n8n/templates/scaledobject-worker.yaml
@@ -9,13 +9,12 @@ metadata:
     app.kubernetes.io/component: worker
   {{- if or .Values.commonAnnotations .Values.keda.worker.pause }}
   annotations:
-    {{- with .Values.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
+    {{- $annotations := deepCopy (.Values.commonAnnotations | default dict) }}
     {{- if .Values.keda.worker.pause }}
-    autoscaling.keda.sh/paused: "true"
-    autoscaling.keda.sh/paused-replicas: "0"
+    {{- $_ := set $annotations "autoscaling.keda.sh/paused" "true" }}
+    {{- $_ := set $annotations "autoscaling.keda.sh/paused-replicas" "0" }}
     {{- end }}
+    {{- toYaml $annotations | nindent 4 }}
   {{- end }}
 spec:
   scaleTargetRef:

--- a/charts/n8n/values.schema.json
+++ b/charts/n8n/values.schema.json
@@ -481,9 +481,9 @@
           "properties": {
             "pause": { "type": "boolean" },
             "pausedReplicaCount": {
-              "type": "integer",
+              "type": ["integer", "null"],
               "minimum": 0,
-              "description": "Replica count to maintain while KEDA autoscaling is paused (autoscaling.keda.sh/paused-replicas)"
+              "description": "Optional replica count to hold while KEDA autoscaling is paused (autoscaling.keda.sh/paused-replicas). Unset freezes workers at their current count."
             }
           }
         }

--- a/charts/n8n/values.schema.json
+++ b/charts/n8n/values.schema.json
@@ -472,6 +472,23 @@
         }
       }
     },
+    "keda": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "worker": {
+          "type": "object",
+          "properties": {
+            "pause": { "type": "boolean" },
+            "pausedReplicaCount": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Replica count to maintain while KEDA autoscaling is paused (autoscaling.keda.sh/paused-replicas)"
+            }
+          }
+        }
+      }
+    },
     "webhook": {
       "type": "object",
       "properties": {

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -491,11 +491,13 @@ hpa:
 keda:
   enabled: false
   worker:
-    # Pause KEDA autoscaling (sets autoscaling.keda.sh/paused=true)
+    # Pause KEDA autoscaling, freezing workers at their current replica count
+    # (sets autoscaling.keda.sh/paused=true)
     pause: false
-    # Replica count to maintain while paused (sets autoscaling.keda.sh/paused-replicas)
-    # Only applied when pause=true. Defaults to 0 (scale workers down).
-    pausedReplicaCount: 0
+    # Optional replica count to hold while paused (sets autoscaling.keda.sh/paused-replicas).
+    # Only applied when pause=true. Leave unset to freeze at the current count;
+    # set 0 to scale workers down to zero, e.g. to drain the queue before a migration.
+    pausedReplicaCount: null
     pollingInterval: 15
     cooldownPeriod: 300
     minReplicaCount: 2

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -491,6 +491,9 @@ hpa:
 keda:
   enabled: false
   worker:
+    # Pause KEDA autoscaling and scale workers to zero
+    # Sets autoscaling.keda.sh/paused=true and autoscaling.keda.sh/paused-replicas=0
+    pause: false
     pollingInterval: 15
     cooldownPeriod: 300
     minReplicaCount: 2

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -491,9 +491,11 @@ hpa:
 keda:
   enabled: false
   worker:
-    # Pause KEDA autoscaling and scale workers to zero
-    # Sets autoscaling.keda.sh/paused=true and autoscaling.keda.sh/paused-replicas=0
+    # Pause KEDA autoscaling (sets autoscaling.keda.sh/paused=true)
     pause: false
+    # Replica count to maintain while paused (sets autoscaling.keda.sh/paused-replicas)
+    # Only applied when pause=true. Defaults to 0 (scale workers down).
+    pausedReplicaCount: 0
     pollingInterval: 15
     cooldownPeriod: 300
     minReplicaCount: 2


### PR DESCRIPTION
# Pull Request

## Description
Adds a `keda.worker.pause` setting to the n8n Helm chart so worker KEDA autoscaling can be paused and workers scaled to zero via ScaledObject annotations.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Example/configuration update
- [x] CI/CD improvements

## Related Issues
Fixes # N/A
Relates to # N/A

## Changes Made
- Added `keda.worker.pause` (`true`/`false`, default `false`) to control KEDA worker autoscaling pause behavior
- When `pause` is `true`, the worker ScaledObject sets `autoscaling.keda.sh/paused: "true"` and `autoscaling.keda.sh/paused-replicas: "0"` to scale workers to zero and pause autoscaling
- Updated README and the KEDA autoscaling example to document the new setting

## Testing Performed
- Rendered the worker ScaledObject with `keda.worker.pause` enabled and disabled

### Chart Validation
- [x] `helm lint charts/n8n` passes
- [ ] `./scripts/validate-examples.sh` passes
- [x] Template rendering works with all examples

### Deployment Testing (if applicable)
- [x] Tested with minimal configuration
- [ ] Tested with production configuration
- [ ] Tested upgrade path from previous version
- [x] All pods start successfully
- [x] Application is accessible

### Specific Testing for Changes
Describe any specific testing you performed for your changes:
- Rendered the chart with `keda.enabled=true` and `keda.worker.pause=false` to confirm pause annotations are omitted.
- Rendered the chart with `keda.worker.pause=true` to confirm both `autoscaling.keda.sh/paused: "true"` and `autoscaling.keda.sh/paused-replicas: "0"` are set on the worker ScaledObject.

## Breaking Changes
If this includes breaking changes, describe what they are and provide migration instructions:
- None. The new setting defaults to `false`, so existing KEDA worker ScaledObjects continue to behave as before.

## Documentation Updates
- [ ] Updated Chart.yaml version (if needed)
- [ ] Updated CHANGELOG.md
- [x] Updated README.md (if needed)
- [x] Updated examples (if needed)
- [ ] Updated CONTRIBUTING.md (if needed)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added examples that demonstrate the changes (if applicable)
- [x] All new and existing tests pass

## Screenshots (if applicable)
Not applicable.

## Additional Notes
This change is backward compatible because `keda.worker.pause` defaults to `false` and only adds pause annotations when explicitly enabled.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `keda.worker.pause` and `keda.worker.pausedReplicaCount` to the Helm chart so KEDA worker autoscaling can be paused, freezing workers at their current count or scaling them to a fixed count (including zero).

- **New Features**
  - `keda.worker.pause` (default `false`) and `keda.worker.pausedReplicaCount` (default `null`) are validated in `values.schema.json`.
  - When `pause=true`, the worker ScaledObject gets `autoscaling.keda.sh/paused: "true"` and merges with `commonAnnotations`.
  - The `paused-replicas` annotation is only added when a count is set: leaving it unset freezes workers at their current count, while `0` scales them to zero.
  - Updated README and `keda-autoscaling.yaml` example.

<sup>Written for commit c0417dcedcd01e06bf82d0c15794592e3931b578. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-hosting/pull/177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

