### PR TITLE
Allow disabling task runners if needed from main pods.

### DIFF
--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -188,7 +188,9 @@ See [`examples/node-placement.yaml`](./examples/node-placement.yaml) for a compl
 
 Task runners execute user-provided JavaScript and Python code in isolated sidecar containers, separate from the main n8n process. When enabled, worker pods get a runner sidecar in queue mode (manual executions are offloaded to workers). In standalone mode (`queueMode.enabled=false`), the main pod gets a runner sidecar instead.
 
-**How it works:** The n8n container runs a task broker on port 5679. The runner sidecar connects to this broker over localhost to receive and execute code tasks.
+**How it works:** The n8n process that executes workflows runs a task broker on port 5679, and its runner sidecar connects to that broker over localhost to receive and execute code tasks. In queue mode the executing process is the worker, so only worker pods run a broker and get a sidecar. n8n does not start a broker on main pods when manual executions are offloaded to workers, which the chart always enables in queue mode.
+
+**Requires n8n 2.13.0 or later.** Earlier versions also run a broker on main pods, and 1.108.0 to 2.12.x need a runner there for the MCP Server Trigger, so pinning `image.tag` below 2.13.0 leaves those executions without a runner. The chart's `appVersion` is always above this floor.
 
 **Enable task runners:**
 ```yaml

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -186,7 +186,7 @@ See [`examples/node-placement.yaml`](./examples/node-placement.yaml) for a compl
 
 ## Task Runners
 
-Task runners execute user-provided JavaScript and Python code in isolated sidecar containers, separate from the main n8n process. When enabled, each main and worker pod gets a runner sidecar.
+Task runners execute user-provided JavaScript and Python code in isolated sidecar containers, separate from the main n8n process. When enabled, worker pods get a runner sidecar in queue mode (manual executions are offloaded to workers). In standalone mode (`queueMode.enabled=false`), the main pod gets a runner sidecar instead.
 
 **How it works:** The n8n container runs a task broker on port 5679. The runner sidecar connects to this broker over localhost to receive and execute code tasks.
 

--- a/charts/n8n/examples/task-runners.yaml
+++ b/charts/n8n/examples/task-runners.yaml
@@ -5,7 +5,7 @@
 # Architecture:
 #   - The n8n container runs a task broker on port 5679
 #   - A runner sidecar container connects to the broker over localhost
-#   - Both main and worker pods get their own runner sidecar
+#   - Worker pods get a runner sidecar (main pods do not; queue mode offloads execution to workers)
 #
 # Prerequisites:
 #   - External PostgreSQL and Redis (queue mode)
@@ -16,7 +16,7 @@ queueMode:
   workerReplicaCount: 3
   workerConcurrency: 10
 
-# Enable task runner sidecars on main and worker pods
+# Enable task runner sidecars on worker pods (queue mode offloads execution from main)
 taskRunners:
   enabled: true
 

--- a/charts/n8n/templates/_configmap-env.tpl
+++ b/charts/n8n/templates/_configmap-env.tpl
@@ -84,23 +84,6 @@ Environment variables from ConfigMap for all components
       name: {{ include "n8n.fullname" . }}
       key: OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS
 {{- end }}
-{{- if .Values.taskRunners.enabled }}
-- name: N8N_RUNNERS_MODE
-  valueFrom:
-    configMapKeyRef:
-      name: {{ include "n8n.fullname" . }}
-      key: N8N_RUNNERS_MODE
-- name: N8N_RUNNERS_AUTH_TOKEN
-  valueFrom:
-    secretKeyRef:
-      {{- if .Values.taskRunners.authToken.existingSecret }}
-      name: {{ .Values.taskRunners.authToken.existingSecret }}
-      key: {{ .Values.taskRunners.authToken.existingSecretKey | default "N8N_RUNNERS_AUTH_TOKEN" }}
-      {{- else }}
-      name: {{ include "n8n.fullname" . }}-task-runners
-      key: N8N_RUNNERS_AUTH_TOKEN
-      {{- end }}
-{{- end }}
 {{- if .Values.queueMode.enabled }}
 {{- if .Values.redis.clusterNodes }}
 - name: QUEUE_BULL_REDIS_CLUSTER_NODES
@@ -253,6 +236,9 @@ Environment variables from ConfigMap for main pods only
       name: {{ include "n8n.fullname" . }}
       key: N8N_DISABLE_PRODUCTION_MAIN_PROCESS
 {{- end }}
+{{- if include "n8n.mainTaskRunnersEnabled" . }}
+{{- include "n8n.taskRunnerConfigMapEnv" . | nindent 0 }}
+{{- end }}
 {{- end }}
 
 {{/*
@@ -304,10 +290,34 @@ Environment variables from ConfigMap for worker pods (webhook URL for resume/wai
       name: {{ include "n8n.fullname" . }}
       key: N8N_EDITOR_BASE_URL
 {{- end }}
+{{- if .Values.taskRunners.enabled }}
+{{- include "n8n.taskRunnerConfigMapEnv" . | nindent 0 }}
+{{- end }}
 {{- end }}
 
 {{/*
-Task Runners environment variables for n8n broker (main and worker pods)
+Task runner ConfigMap-backed environment variables (main in standalone mode, workers in queue mode)
+*/}}
+{{- define "n8n.taskRunnerConfigMapEnv" -}}
+- name: N8N_RUNNERS_MODE
+  valueFrom:
+    configMapKeyRef:
+      name: {{ include "n8n.fullname" . }}
+      key: N8N_RUNNERS_MODE
+- name: N8N_RUNNERS_AUTH_TOKEN
+  valueFrom:
+    secretKeyRef:
+      {{- if .Values.taskRunners.authToken.existingSecret }}
+      name: {{ .Values.taskRunners.authToken.existingSecret }}
+      key: {{ .Values.taskRunners.authToken.existingSecretKey | default "N8N_RUNNERS_AUTH_TOKEN" }}
+      {{- else }}
+      name: {{ include "n8n.fullname" . }}-task-runners
+      key: N8N_RUNNERS_AUTH_TOKEN
+      {{- end }}
+{{- end }}
+
+{{/*
+Task Runners environment variables for n8n broker (main in standalone mode, workers in queue mode)
 */}}
 {{- define "n8n.taskRunnerBrokerEnv" -}}
 {{- if .Values.taskRunners.enabled }}

--- a/charts/n8n/templates/_helpers.tpl
+++ b/charts/n8n/templates/_helpers.tpl
@@ -181,3 +181,12 @@ Validate values — called once from deployment-main.yaml to fail fast on bad co
 {{- end -}}
 
 {{- end -}}
+
+{{/*
+Task runners on main pods: only in standalone mode.
+In queue mode, manual executions are offloaded to workers (OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS),
+so workers handle code execution and main pods do not need runner sidecars.
+*/}}
+{{- define "n8n.mainTaskRunnersEnabled" -}}
+{{- if and .Values.taskRunners.enabled (not .Values.queueMode.enabled) -}}true{{- end -}}
+{{- end -}}

--- a/charts/n8n/templates/configmap.yaml
+++ b/charts/n8n/templates/configmap.yaml
@@ -51,6 +51,10 @@ data:
   # Queue configuration
   {{- if .Values.queueMode.enabled }}
   EXECUTIONS_MODE: "queue"
+  # Always "true", and "n8n.mainTaskRunnersEnabled" depends on it: n8n skips
+  # task runner startup on main when offloading is on, so the chart drops the
+  # main-pod sidecar. If this ever becomes configurable, that helper must read
+  # it rather than queueMode.enabled.
   OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS: "true"
   {{- end }}
   # Task runner configuration (only emitted when sidecars are enabled,

--- a/charts/n8n/templates/deployment-main.yaml
+++ b/charts/n8n/templates/deployment-main.yaml
@@ -140,8 +140,10 @@ spec:
             # Core n8n secrets
             {{- include "n8n.coreSecretsEnv" . | nindent 12 }}
 
-            # Task Runners Configuration
+            # Task Runners Configuration (standalone mode only; queue mode offloads execution to workers)
+            {{- if include "n8n.mainTaskRunnersEnabled" . }}
             {{- include "n8n.taskRunnerBrokerEnv" . | nindent 12 }}
+            {{- end }}
 
             {{- with .Values.config.extraEnv }}
             {{- toYaml . | nindent 12 }}
@@ -197,7 +199,7 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
 
-        {{- if .Values.taskRunners.enabled }}
+        {{- if include "n8n.mainTaskRunnersEnabled" . }}
         # Task Runner sidecar container
         - name: task-runner
           image: "{{ .Values.taskRunners.image.repository }}:{{ default .Values.image.tag .Values.taskRunners.image.tag }}"
@@ -237,7 +239,7 @@ spec:
         - name: data
           emptyDir: {}
         {{- end }}
-        {{- if and .Values.taskRunners.enabled .Values.taskRunners.customConfig.enabled }}
+        {{- if and (include "n8n.mainTaskRunnersEnabled" .) .Values.taskRunners.customConfig.enabled }}
         - name: task-runner-config
           configMap:
             name: {{ .Values.taskRunners.customConfig.configMapName }}

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -79,7 +79,9 @@ multiMain:
 # ----- Task Runners (external mode with sidecar containers) -----
 taskRunners:
   # Enable task runners for executing user-provided JavaScript and Python code
-  # When enabled, a sidecar container (n8nio/runners) is added to main and worker pods
+  # When enabled, a sidecar container (n8nio/runners) is added to:
+  #   - worker pods in queue mode (main offloads manual executions to workers)
+  #   - main pods in standalone mode (queueMode.enabled=false)
   enabled: false
 
   # Task runner image configuration


### PR DESCRIPTION
Resolves #178 

# Pull Request 

## Description
Skips task runner sidecars on main pods when queue mode is enabled. In queue mode, manual executions are offloaded to workers (`OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS`), so main pods no longer need runner sidecars or broker configuration. Task runners remain enabled on worker pods in queue mode and on main pods in standalone mode.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Example/configuration update
- [ ] CI/CD improvements

## Related Issues
Fixes # N/A
Relates to # N/A

## Changes Made
- Added `n8n.mainTaskRunnersEnabled` helper — true only when `taskRunners.enabled=true` and `queueMode.enabled=false`
- Updated `deployment-main.yaml` to deploy task runner sidecars, broker env vars, and config volumes only when `n8n.mainTaskRunnersEnabled` is true
- Moved task runner env vars out of shared ConfigMap env into component-specific sections (`mainConfigMapEnv` for standalone, `workerConfigMapEnv` for queue mode workers)
- Added `n8n.taskRunnerConfigMapEnv` partial for reusable task runner ConfigMap-backed env vars
- Updated `values.yaml`, `README.md`, and `examples/task-runners.yaml` to document the queue-mode vs standalone behavior

## Testing Performed
- Rendered the chart with queue mode and `taskRunners.enabled=true` to confirm main pods have no task runner sidecar or `N8N_RUNNERS_*` env vars, while worker pods still do
- Rendered the chart in standalone mode with `taskRunners.enabled=true` to confirm main pods still get the task runner sidecar and broker env vars

### Chart Validation
- [x] `helm lint charts/n8n` passes
- [ ] `./scripts/validate-examples.sh` passes
- [x] Template rendering works with all examples

### Deployment Testing (if applicable)
- [ ] Tested with minimal configuration
- [ ] Tested with production configuration
- [ ] Tested upgrade path from previous version
- [ ] All pods start successfully
- [ ] Application is accessible

### Specific Testing for Changes
Describe any specific testing you performed for your changes:
- Rendered with `examples/task-runners.yaml` (queue mode): main deployment containers = `['n8n-main']`, worker deployment containers = `['n8n-worker', 'task-runner']`
- Rendered with `queueMode.enabled=false` and `taskRunners.enabled=true`: main deployment containers = `['n8n-main', 'task-runner']`
- Confirmed main pods in queue mode receive no `N8N_RUNNERS_*` environment variables; worker pods receive `N8N_RUNNERS_MODE`, `N8N_RUNNERS_AUTH_TOKEN`, `N8N_RUNNERS_BROKER_LISTEN_ADDRESS`, and `N8N_NATIVE_PYTHON_RUNNER`

## Breaking Changes
If this includes breaking changes, describe what they are and provide migration instructions:
- None for typical queue-mode deployments. Main pods in queue mode will no longer run task runner sidecars on upgrade, which is the intended behavior — workers already handle code execution.
- If you relied on task runners running on main pods while queue mode was enabled (e.g. a custom setup that disabled worker offloading), re-enable runners on main by setting `queueMode.enabled=false` or adjust your deployment accordingly.

## Documentation Updates
- [ ] Updated Chart.yaml version (if needed)
- [ ] Updated CHANGELOG.md
- [x] Updated README.md (if needed)
- [x] Updated examples (if needed)
- [ ] Updated CONTRIBUTING.md (if needed)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added examples that demonstrate the changes (if applicable)
- [ ] All new and existing tests pass

## Screenshots (if applicable)
Not applicable.

## Additional Notes
This change reduces wasted CPU and memory on main pods in queue mode. The ConfigMap still emits task runner keys when `taskRunners.enabled=true` so worker pods can reference them; only main pod deployment and env injection are gated.
