### PR TITLE
feat(chart): add imagePullSecrets option

### DIFF
--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -122,6 +122,7 @@ To use the namespace's default ServiceAccount, set `name: ""`. If you set `creat
 |---|---|---|
 | `image.repository` | n8n image | `docker.n8n.io/n8nio/n8n` |
 | `image.tag` | n8n version | `1.110.1` |
+| `imagePullSecrets` | Existing pull Secrets for private image registries | `[]` |
 | `queueMode.workerReplicaCount` | Number of worker pods | `2` |
 | `queueMode.workerConcurrency` | Jobs per worker | `10` |
 | `multiMain.enabled` | Multi-main HA (Enterprise) | `false` |

--- a/charts/n8n/templates/deployment-main.yaml
+++ b/charts/n8n/templates/deployment-main.yaml
@@ -31,6 +31,10 @@ spec:
       labels:
         {{- include "n8n.podLabels" (dict "root" . "component" "main") | nindent 8 }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with include "n8n.serviceAccountName" . }}
       serviceAccountName: {{ . }}
       {{- end }}

--- a/charts/n8n/templates/deployment-webhook-processor.yaml
+++ b/charts/n8n/templates/deployment-webhook-processor.yaml
@@ -27,6 +27,10 @@ spec:
       labels:
         {{- include "n8n.podLabels" (dict "root" . "component" "webhook-processor") | nindent 8 }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with include "n8n.serviceAccountName" . }}
       serviceAccountName: {{ . }}
       {{- end }}

--- a/charts/n8n/templates/deployment-worker.yaml
+++ b/charts/n8n/templates/deployment-worker.yaml
@@ -27,6 +27,10 @@ spec:
       labels:
         {{- include "n8n.podLabels" (dict "root" . "component" "worker") | nindent 8 }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with include "n8n.serviceAccountName" . }}
       serviceAccountName: {{ . }}
       {{- end }}

--- a/charts/n8n/templates/tests/test-connection.yaml
+++ b/charts/n8n/templates/tests/test-connection.yaml
@@ -11,6 +11,10 @@ metadata:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
+  {{- with .Values.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   containers:
     - name: wget
       image: busybox:1.36

--- a/charts/n8n/values.schema.json
+++ b/charts/n8n/values.schema.json
@@ -15,6 +15,18 @@
       },
       "required": ["repository", "tag"]
     },
+    "imagePullSecrets": {
+      "type": "array",
+      "default": [],
+      "description": "Existing pull Secrets for private image repositories, referenced by every pod the chart creates",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string", "minLength": 1 }
+        },
+        "required": ["name"]
+      }
+    },
     "replicaCount": { "type": "integer", "minimum": 1 },
     "commonLabels": {
       "type": "object",

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -4,6 +4,15 @@ image:
   tag: "stable"
   pullPolicy: IfNotPresent
 
+# ----- Image pull secrets -----
+# This is for the secrets for pulling an image from a
+# private repository, more information can be found here:
+# https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+imagePullSecrets: []
+# Example:
+# imagePullSecrets:
+#   - name: my-registry-credentials
+
 # ----- Names -----
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
# Pull Request

## Description
Adds the possibility to define imagePullSecrets, so that one can either use their own (private) image or add their credentials in order to log into a public registry.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Changes Made
- added `imagePullSecrets` to values.yaml, README.md, values.schema.json and all deployments 

## Testing Performed

### Chart Validation
- [x] `helm lint charts/n8n` passes
- [ ] `./scripts/validate-examples.sh` passes (<- Doesn't exist in the project?)
- [x] Template rendering works with all examples

### Deployment Testing (if applicable)
- [x] Tested with minimal configuration
- [x] All pods start successfully
- [x] Application is accessible

## Documentation Updates
- [x] Updated README.md (if needed)

## Checklist
- [ ] My code follows the project's style guidelines (<- I guess so?)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added examples that demonstrate the changes (if applicable)
- [ ] All new and existing tests pass (please add the `test-install` label to this PR, can't seem to do it myself)

## Additional Notes
I need this in order to log in to `docker.io` and pull the image from there, because `docker.n8n.io` gives me a `TOOMANYREQUESTS` because I scan my images for CVEs (apparently too) frequently.

The comment in the `values.yaml` was taken from the default Helm skeleton (created by `helm create`).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `imagePullSecrets` to the n8n Helm chart to let pods pull images from private registries or authenticated public registries.

- **New Features**
  - New `imagePullSecrets` value (array of `{ name }`) with schema validation and docs in `values.yaml`, `values.schema.json`, and `README.md`.
  - Injects `imagePullSecrets` into all chart-created pods: main, worker, webhook-processor, and the Helm test pod.

<sup>Written for commit e4f2594fd38b759cdff6cd0e8f498d2fb7215466. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-hosting/pull/180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

