### PR TITLE
fix(chart): emit N8N_WEBHOOK_URL instead of deprecated WEBHOOK_URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Run chart-testing (lint)
         run: ct lint --chart-dirs charts --charts charts/n8n --validate-maintainers=false
 
+      - name: Check for deprecated n8n env vars
+        run: ./scripts/check-deprecated-env.sh charts/n8n
+
   template-validation:
     runs-on: ubuntu-latest
     strategy:

--- a/charts/n8n/examples/minimal-with-docker.yaml
+++ b/charts/n8n/examples/minimal-with-docker.yaml
@@ -72,7 +72,7 @@ config:
     # Local development settings
     - name: N8N_LOG_LEVEL
       value: "debug"
-    - name: WEBHOOK_URL
+    - name: N8N_WEBHOOK_URL
       value: "http://localhost:8080/webhook"
     - name: N8N_EDITOR_BASE_URL
       value: "http://localhost:8080"

--- a/charts/n8n/templates/_configmap-env.tpl
+++ b/charts/n8n/templates/_configmap-env.tpl
@@ -204,11 +204,11 @@ Environment variables from ConfigMap for main pods only
 {{- define "n8n.mainConfigMapEnv" -}}
 {{- if .Values.webhook.enabled }}
 {{- if or .Values.webhook.url (and .Values.ingress .Values.ingress.enabled (gt (len .Values.ingress.hosts) 0)) }}
-- name: WEBHOOK_URL
+- name: N8N_WEBHOOK_URL
   valueFrom:
     configMapKeyRef:
       name: {{ include "n8n.fullname" . }}
-      key: WEBHOOK_URL
+      key: N8N_WEBHOOK_URL
 {{- end }}
 {{- if .Values.webhook.timeout }}
 - name: N8N_WEBHOOK_TIMEOUT
@@ -261,11 +261,11 @@ Environment variables from ConfigMap for webhook processor pods (similar to main
 {{- define "n8n.webhookProcessorConfigMapEnv" -}}
 {{- if .Values.webhook.enabled }}
 {{- if or .Values.webhook.url (and .Values.ingress .Values.ingress.enabled (gt (len .Values.ingress.hosts) 0)) }}
-- name: WEBHOOK_URL
+- name: N8N_WEBHOOK_URL
   valueFrom:
     configMapKeyRef:
       name: {{ include "n8n.fullname" . }}
-      key: WEBHOOK_URL
+      key: N8N_WEBHOOK_URL
 {{- end }}
 {{- if .Values.webhook.timeout }}
 - name: N8N_WEBHOOK_TIMEOUT
@@ -290,11 +290,11 @@ Environment variables from ConfigMap for worker pods (webhook URL for resume/wai
 {{- define "n8n.workerConfigMapEnv" -}}
 {{- if .Values.webhook.enabled }}
 {{- if or .Values.webhook.url (and .Values.ingress .Values.ingress.enabled (gt (len .Values.ingress.hosts) 0)) }}
-- name: WEBHOOK_URL
+- name: N8N_WEBHOOK_URL
   valueFrom:
     configMapKeyRef:
       name: {{ include "n8n.fullname" . }}
-      key: WEBHOOK_URL
+      key: N8N_WEBHOOK_URL
 {{- end }}
 {{- end }}
 {{- if or (and .Values.ingress .Values.ingress.enabled (gt (len .Values.ingress.hosts) 0)) (and .Values.webhook.url (hasPrefix "http" (.Values.webhook.url | toString))) }}

--- a/charts/n8n/templates/configmap.yaml
+++ b/charts/n8n/templates/configmap.yaml
@@ -109,9 +109,9 @@ data:
   # ----- Main-only Configuration -----
   {{- if .Values.webhook.enabled }}
   {{- if .Values.webhook.url }}
-  WEBHOOK_URL: {{ .Values.webhook.url | quote }}
+  N8N_WEBHOOK_URL: {{ .Values.webhook.url | quote }}
   {{- else if and .Values.ingress .Values.ingress.enabled (gt (len .Values.ingress.hosts) 0) }}
-  WEBHOOK_URL: "https://{{ (index .Values.ingress.hosts 0).host }}"
+  N8N_WEBHOOK_URL: "https://{{ (index .Values.ingress.hosts 0).host }}"
   {{- end }}
   {{- if .Values.webhook.timeout }}
   N8N_WEBHOOK_TIMEOUT: "{{ .Values.webhook.timeout }}"

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -527,6 +527,8 @@ webhook:
   enabled: true
   # Custom webhook URL base domain (if not set, will use ingress host)
   # Format: https://your-domain.com (n8n adds /webhook path automatically)
+  # Rendered as N8N_WEBHOOK_URL, which sets the base URL for both test and
+  # production webhooks.
   url: ""
   # Timeout for webhook requests in milliseconds
   timeout: 120000

--- a/scripts/check-deprecated-env.sh
+++ b/scripts/check-deprecated-env.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Fails if the chart renders an environment variable that n8n has deprecated.
+#
+# Render-only on purpose: no cluster, no licence, runs in seconds. That matters
+# because some of these variables only appear under configurations CI cannot
+# actually boot (S3 binary storage is licence-gated), so a runtime test would
+# never reach them.
+#
+# Only variables the CHART emits belong here. n8n also warns about several
+# variables because they are UNSET, asking operators to pin a default before it
+# changes; those cannot be detected by grepping rendered output and are the
+# deployer's call, not the chart's.
+#
+# When n8n deprecates another variable the chart sets, add it to DEPRECATED and
+# add a scenario below that exercises the path emitting it.
+set -uo pipefail
+
+CHART="${1:-charts/n8n}"
+KEY="--set secretRefs.env.N8N_ENCRYPTION_KEY=ci-placeholder-key-long-enough"
+
+DEPRECATED=(
+  "WEBHOOK_URL"
+)
+
+SCENARIOS=(
+  "webhook-url|--set webhook.url=https://hooks.example.com"
+  "ingress|--set ingress.enabled=true"
+  "s3|--set s3.enabled=true --set s3.storage.mode=s3 --set s3.bucket.name=b --set s3.bucket.region=us-east-1 --set s3.auth.accessKeyId=A --set s3.auth.secretAccessKey=S"
+  "queue-all-tiers|--set webhook.url=https://hooks.example.com --set redis.enabled=true --set worker.enabled=true --set webhookProcessor.enabled=true"
+)
+
+rc=0
+for scenario in "${SCENARIOS[@]}"; do
+  name="${scenario%%|*}"
+  flags="${scenario#*|}"
+
+  if ! out=$(helm template ci "$CHART" $KEY $flags 2>&1); then
+    echo "render failed [$name]"
+    echo "$out" | grep -i error | head -2
+    rc=1
+    continue
+  fi
+
+  for var in "${DEPRECATED[@]}"; do
+    # Word-boundary match, so N8N_WEBHOOK_URL does not match WEBHOOK_URL.
+    if echo "$out" | grep -qE "(^|[^A-Z0-9_])${var}([^A-Z0-9_]|$)"; then
+      echo "FAIL [$name] chart renders deprecated env var: $var"
+      rc=1
+    fi
+  done
+done
+
+if [ $rc -eq 0 ]; then
+  echo "PASS: no deprecated env vars rendered"
+fi
+exit $rc

--- a/scripts/check-deprecated-env.sh
+++ b/scripts/check-deprecated-env.sh
@@ -26,7 +26,7 @@ DEPRECATED=(
 SCENARIOS=(
   "webhook-url|--set webhook.url=https://hooks.example.com"
   "ingress|--set ingress.enabled=true"
-  "s3|--set s3.enabled=true --set s3.storage.mode=s3 --set s3.bucket.name=b --set s3.bucket.region=us-east-1 --set s3.auth.accessKeyId=A --set s3.auth.secretAccessKey=S"
+  "s3|--set s3.enabled=true --set s3.storage.mode=s3 --set s3.bucket.name=b --set s3.bucket.region=us-east-1 --set s3.auth.accessKeyId=A --set s3.auth.secretAccessKeySecret.name=s3-creds --set s3.auth.secretAccessKeySecret.key=secretKey"
   "queue-all-tiers|--set webhook.url=https://hooks.example.com --set redis.enabled=true --set worker.enabled=true --set webhookProcessor.enabled=true"
 )
 
@@ -43,8 +43,13 @@ for scenario in "${SCENARIOS[@]}"; do
   fi
 
   for var in "${DEPRECATED[@]}"; do
-    # Word-boundary match, so N8N_WEBHOOK_URL does not match WEBHOOK_URL.
-    if echo "$out" | grep -qE "(^|[^A-Z0-9_])${var}([^A-Z0-9_]|$)"; then
+    # Match only the positions where the chart can emit an env var name: an
+    # env entry ("name: VAR"), a configMapKeyRef ("key: VAR"), or a ConfigMap
+    # data key ("VAR:" at the start of a line). Values never match, so a URL
+    # containing the deprecated name cannot false-positive, and N8N_WEBHOOK_URL
+    # does not match WEBHOOK_URL. Here-string, not a pipe: with pipefail, grep
+    # -q exiting early can SIGPIPE the writer and turn a hit into a miss.
+    if grep -qE "((name|key): ${var}$)|(^[[:space:]]*${var}:)" <<< "$out"; then
       echo "FAIL [$name] chart renders deprecated env var: $var"
       rc=1
     fi


### PR DESCRIPTION

## Description

n8n deprecated `WEBHOOK_URL` and replaced it with `N8N_WEBHOOK_URL`, but the
chart still emits the old name. Every deployment with `webhook.enabled: true`
logs a deprecation warning on startup and there's no value you can set to stop
it.

From `packages/cli/src/deprecation/deprecation.service.ts:66-68`:

> Use `N8N_WEBHOOK_URL` instead, which sets the base URL for both test and
> production webhooks.

`configmap.yaml` sets `WEBHOOK_URL` from `.Values.webhook.url`, falling back to
the first ingress host. There's no alternative path and no `N8N_WEBHOOK_URL`
support anywhere in the chart, so operators can't silence it from values. It has
to change here.

Verified against chart `v1.11.0` and `n8n@2.36.0`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Example/configuration update
- [ ] CI/CD improvements

## Related Issues

Relates to # (n8n deprecation warnings under chart v1.11.0)

## Changes Made

- `templates/configmap.yaml`: renamed the ConfigMap key `WEBHOOK_URL` to `N8N_WEBHOOK_URL` in both branches (explicit `webhook.url` and the ingress-host fallback)
- `templates/_configmap-env.tpl`: renamed the env var and `configMapKeyRef` key in all three consumers, `n8n.mainConfigMapEnv` (~205), `n8n.webhookProcessorConfigMapEnv` (~263), `n8n.workerConfigMapEnv` (~292)
- `values.yaml`: comment only, noting `webhook.url` now renders as `N8N_WEBHOOK_URL`
- `examples/minimal-with-docker.yaml`: this example set `WEBHOOK_URL` directly in `config.extraEnv`, so it would have kept emitting the deprecated name regardless of the template fix
- `scripts/check-deprecated-env.sh` (new) + a `ci.yml` step: renders the chart across the scenarios that emit `WEBHOOK_URL` (explicit `webhook.url`, ingress fallback, and all three queue-mode tiers) and fails the build if the deprecated name reappears

No user-facing value changes. `webhook.url` keeps its name and meaning.

### The diff

`charts/n8n/templates/configmap.yaml`:

```diff
@@ -109,9 +109,9 @@
   # ----- Main-only Configuration -----
   {{- if .Values.webhook.enabled }}
   {{- if .Values.webhook.url }}
-  WEBHOOK_URL: {{ .Values.webhook.url | quote }}
+  N8N_WEBHOOK_URL: {{ .Values.webhook.url | quote }}
   {{- else if and .Values.ingress .Values.ingress.enabled (gt (len .Values.ingress.hosts) 0) }}
-  WEBHOOK_URL: "https://{{ (index .Values.ingress.hosts 0).host }}"
+  N8N_WEBHOOK_URL: "https://{{ (index .Values.ingress.hosts 0).host }}"
   {{- end }}
```

`charts/n8n/templates/_configmap-env.tpl`, the same block in all three helpers:

```diff
 {{- if or .Values.webhook.url (and .Values.ingress .Values.ingress.enabled (gt (len .Values.ingress.hosts) 0)) }}
-- name: WEBHOOK_URL
+- name: N8N_WEBHOOK_URL
   valueFrom:
     configMapKeyRef:
       name: {{ include "n8n.fullname" . }}
-      key: WEBHOOK_URL
+      key: N8N_WEBHOOK_URL
 {{- end }}
```

`charts/n8n/values.yaml` ~528:

```diff
   # Custom webhook URL base domain (if not set, will use ingress host)
   # Format: https://your-domain.com (n8n adds /webhook path automatically)
+  # Rendered as N8N_WEBHOOK_URL, which sets the base URL for both test and
+  # production webhooks.
   url: ""
```

`scripts/check-deprecated-env.sh` (new), wired into the `lint` job right after `ct lint`. Render-only, no cluster or licence needed, so it's cheap enough to run on every PR:

```bash
DEPRECATED=(
  "WEBHOOK_URL"
)

SCENARIOS=(
  "webhook-url|--set webhook.url=https://hooks.example.com"
  "ingress|--set ingress.enabled=true"
  "queue-all-tiers|--set webhook.url=https://hooks.example.com --set redis.enabled=true --set worker.enabled=true --set webhookProcessor.enabled=true"
)
```

The match is anchored to the three positions the chart can emit an env var name
(env `name:`, `configMapKeyRef` `key:`, ConfigMap data key), so `N8N_WEBHOOK_URL`
never matches `WEBHOOK_URL` and a value containing the deprecated name (say a
`webhook.url` with `WEBHOOK_URL` as a path segment) can't false-positive either:

```bash
if grep -qE "((name|key): ${var}$)|(^[[:space:]]*${var}:)" <<< "$out"; then
```

## Testing Performed

### Chart Validation

- [x] `helm lint charts/n8n` passes (helm v4.2.3, 1 chart linted, 0 failed)
- [x] `ct lint --chart-dirs charts --charts charts/n8n --validate-maintainers=false` passes (ct 3.14.0)
- [x] Template rendering works with all examples (10/10 render, matching the `ci.yml` matrix)

### Deployment Testing

- [x] Tested with minimal configuration
- [ ] Tested with production configuration
- [x] Tested upgrade path from previous version (upgraded in place from unpatched `main`)
- [x] All pods start successfully
- [x] Application is accessible (`helm test n8n` passes)

Run locally on kind v0.32.0 (k8s v1.36.1) following the same sequence as the
`install-test` job: bitnami postgres and redis, the CI secrets, then
`helm install` with the CI flags. n8n image `stable`, resolved to 2.36.7.

### Specific Testing for Changes

Note the chart requires an encryption key or templating fails before it reaches
anything relevant. Quote the `ingress.hosts[0]` index too, zsh globs it
otherwise.

```bash
# ingress host fallback
helm template n8n ./charts/n8n \
  --set secretRefs.env.N8N_ENCRYPTION_KEY=testkey1234567890 \
  --set ingress.enabled=true | grep N8N_WEBHOOK_URL
# result: N8N_WEBHOOK_URL: "https://n8n.example.com"

# explicit webhook.url
helm template n8n ./charts/n8n \
  --set secretRefs.env.N8N_ENCRYPTION_KEY=testkey1234567890 \
  --set webhook.url=https://hooks.example.com | grep N8N_WEBHOOK_URL
# result: N8N_WEBHOOK_URL: "https://hooks.example.com"

# all three tiers in queue mode
helm template n8n ./charts/n8n \
  --set secretRefs.env.N8N_ENCRYPTION_KEY=testkey1234567890 \
  --set webhook.url=https://hooks.example.com \
  --set redis.enabled=true --set worker.enabled=true \
  --set webhookProcessor.enabled=true | grep -c 'name: N8N_WEBHOOK_URL'
# result: 3 (main, webhook processor, worker)

# webhooks disabled, neither key present
helm template n8n ./charts/n8n \
  --set secretRefs.env.N8N_ENCRYPTION_KEY=testkey1234567890 \
  --set webhook.enabled=false | grep -c WEBHOOK_URL
# result: 0

# no bare WEBHOOK_URL left anywhere in the chart
grep -rn WEBHOOK_URL charts/n8n/ | grep -v N8N_WEBHOOK_URL | grep -v N8N_WEBHOOK_TIMEOUT
# result: no matches

# every bundled example still renders
for f in charts/n8n/examples/*.yaml; do
  helm template test charts/n8n -f "$f" \
    --set secretRefs.env.N8N_ENCRYPTION_KEY=testkey1234567890 \
    --dry-run=client > /dev/null 2>&1 && echo "ok $f" || echo "FAIL $f"
done
# result: 10 ok, 0 failed
```

### Runtime proof, with a control

Installed unpatched `main` first with `--set webhook.url=https://hooks.example.com`,
then upgraded the same release onto this branch with identical values.

Before, on `main`:

```
There are deprecations related to your n8n setup...
 - WEBHOOK_URL -> Use N8N_WEBHOOK_URL instead, which sets the base URL for both test and production webhooks.
```

After, on this branch, the same four unset-variable deprecations remain and the
`WEBHOOK_URL` line is gone:

```
There are deprecations related to your n8n setup...
 - N8N_UNVERIFIED_PACKAGES_ENABLED -> ...
 - N8N_RUNNERS_TASK_TIMEOUT -> ...
 - N8N_COMPRESSION_NODE_MAX_DECOMPRESSED_SIZE_BYTES -> ...
 - N8N_COMPRESSION_NODE_MAX_ZIP_ENTRIES -> ...
```

Env vars on the running main pod afterwards: `N8N_WEBHOOK_URL` and
`N8N_WEBHOOK_TIMEOUT`, no bare `WEBHOOK_URL`.

The four that remain are unrelated: they fire because they are unset, not
because the chart sets them. Out of scope here.

### Guard revert test

A guard that always passes is worse than no guard, so I checked it actually goes red on the bug it exists to catch. Restored `configmap.yaml` from `main` onto this branch:

```
FAIL: webhook-url still renders WEBHOOK_URL
FAIL: ingress still renders WEBHOOK_URL
FAIL: queue-all-tiers still renders WEBHOOK_URL
exit 1
```

Restored the fix, ran again:

```
PASS (3/3 scenarios clean)
exit 0
```

## Breaking Changes

None. The renamed key lives inside the chart's own ConfigMap and every reader of
it is updated in the same diff, so nothing outside the chart references it by
name.

Worth flagging for review: on upgrade the ConfigMap is rewritten and the env
blocks change, so pods roll. That's normal for a value change, just not a no-op
deploy.

## Documentation Updates

- [ ] Updated Chart.yaml version (CONTRIBUTING says not to, release-please handles it)
- [ ] Updated CHANGELOG.md
- [ ] Updated README.md (no mention of `WEBHOOK_URL`, checked)
- [x] Updated examples (`minimal-with-docker.yaml` set the deprecated env var directly)
- [ ] Updated CONTRIBUTING.md (if needed)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added examples that demonstrate the changes (`minimal-with-docker.yaml` updated)
- [x] All new and existing tests pass (lint plus the full example matrix)

## Additional Notes

On emitting both names during a transition release: deliberately not doing that.
Rendering `WEBHOOK_URL` alongside the new name keeps the warning firing, which is
the whole problem this fixes, and leaves a second key to remove later.

The one case that would argue otherwise is an external consumer reading
`WEBHOOK_URL` straight out of the rendered ConfigMap. That's outside the chart's
contract and I don't know of one, but flagging it in case a reviewer does.

There's a companion PR removing `N8N_AVAILABLE_BINARY_DATA_MODES` (#185). Both add
`scripts/check-deprecated-env.sh`, each scoped to the one variable it fixes, since
listing both in a single PR would fail on the other PR's still-open bug. Whichever
merges second gets a one-line add/add conflict on that script; the fix is to union
the `DEPRECATED` array. Confirmed by merging both branches locally, the guard passes
clean with both variables listed.

Thoughts?
