### PR TITLE
fix(chart): drop deprecated N8N_AVAILABLE_BINARY_DATA_MODES

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Run chart-testing (lint)
         run: ct lint --chart-dirs charts --charts charts/n8n --validate-maintainers=false
 
+      - name: Check for deprecated n8n env vars
+        run: ./scripts/check-deprecated-env.sh charts/n8n
+
   template-validation:
     runs-on: ubuntu-latest
     strategy:

--- a/charts/n8n/examples/multi-main-queue.yaml
+++ b/charts/n8n/examples/multi-main-queue.yaml
@@ -64,7 +64,6 @@ s3:
     autoDetect: true  # Using IRSA
   storage:
     mode: "s3"
-    availableModes: "filesystem,s3"
 
 # Service account with enterprise IAM role
 serviceAccount:

--- a/charts/n8n/examples/production-s3.yaml
+++ b/charts/n8n/examples/production-s3.yaml
@@ -77,7 +77,6 @@ s3:
   
   storage:
     mode: "s3"
-    availableModes: "filesystem,s3"
 
 # Service Account with AWS IAM Role
 serviceAccount:

--- a/charts/n8n/templates/_environment-helpers.tpl
+++ b/charts/n8n/templates/_environment-helpers.tpl
@@ -6,8 +6,6 @@ S3 External Storage environment variables
 # S3 External Storage Configuration
 - name: N8N_DEFAULT_BINARY_DATA_MODE
   value: {{ .Values.s3.storage.mode | quote }}
-- name: N8N_AVAILABLE_BINARY_DATA_MODES
-  value: {{ .Values.s3.storage.availableModes | quote }}
 - name: N8N_EXTERNAL_STORAGE_S3_BUCKET_NAME
   value: {{ .Values.s3.bucket.name | quote }}
 - name: N8N_EXTERNAL_STORAGE_S3_BUCKET_REGION

--- a/charts/n8n/values.schema.json
+++ b/charts/n8n/values.schema.json
@@ -693,10 +693,6 @@
               "enum": ["filesystem", "s3"],
               "description": "Binary data storage mode"
             },
-            "availableModes": {
-              "type": "string",
-              "description": "Available binary data modes (comma-separated)"
-            },
             "forcePathStyle": { "type": "boolean" },
             "extraEnv": {
               "type": "array",

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -677,8 +677,6 @@ s3:
   storage:
     # Binary data storage mode (filesystem or s3 (filesystem))
     mode: "filesystem"
-    # Available binary data modes (comma-separated ex: filesystem,s3)
-    availableModes: "filesystem"              # <-- Available storage modes for n8n
     # S3 specific settings
     forcePathStyle: false                      # <-- Force path-style URLs (for S3-compatible providers)
     # Additional S3 environment variables

--- a/scripts/check-deprecated-env.sh
+++ b/scripts/check-deprecated-env.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Fails if the chart renders an environment variable that n8n has deprecated.
+#
+# Render-only on purpose: no cluster, no licence, runs in seconds. That matters
+# because some of these variables only appear under configurations CI cannot
+# actually boot (S3 binary storage is licence-gated), so a runtime test would
+# never reach them.
+#
+# Only variables the CHART emits belong here. n8n also warns about several
+# variables because they are UNSET, asking operators to pin a default before it
+# changes; those cannot be detected by grepping rendered output and are the
+# deployer's call, not the chart's.
+#
+# When n8n deprecates another variable the chart sets, add it to DEPRECATED and
+# add a scenario below that exercises the path emitting it.
+set -uo pipefail
+
+CHART="${1:-charts/n8n}"
+KEY="--set secretRefs.env.N8N_ENCRYPTION_KEY=ci-placeholder-key-long-enough"
+
+DEPRECATED=(
+  "N8N_AVAILABLE_BINARY_DATA_MODES"
+)
+
+SCENARIOS=(
+  "webhook-url|--set webhook.url=https://hooks.example.com"
+  "ingress|--set ingress.enabled=true"
+  "s3|--set s3.enabled=true --set s3.storage.mode=s3 --set s3.bucket.name=b --set s3.bucket.region=us-east-1 --set s3.auth.accessKeyId=A --set s3.auth.secretAccessKey=S"
+  "queue-all-tiers|--set webhook.url=https://hooks.example.com --set redis.enabled=true --set worker.enabled=true --set webhookProcessor.enabled=true"
+)
+
+rc=0
+for scenario in "${SCENARIOS[@]}"; do
+  name="${scenario%%|*}"
+  flags="${scenario#*|}"
+
+  if ! out=$(helm template ci "$CHART" $KEY $flags 2>&1); then
+    echo "render failed [$name]"
+    echo "$out" | grep -i error | head -2
+    rc=1
+    continue
+  fi
+
+  for var in "${DEPRECATED[@]}"; do
+    # Word-boundary match, so N8N_WEBHOOK_URL does not match WEBHOOK_URL.
+    if echo "$out" | grep -qE "(^|[^A-Z0-9_])${var}([^A-Z0-9_]|$)"; then
+      echo "FAIL [$name] chart renders deprecated env var: $var"
+      rc=1
+    fi
+  done
+done
+
+if [ $rc -eq 0 ]; then
+  echo "PASS: no deprecated env vars rendered"
+fi
+exit $rc

--- a/scripts/check-deprecated-env.sh
+++ b/scripts/check-deprecated-env.sh
@@ -26,7 +26,7 @@ DEPRECATED=(
 SCENARIOS=(
   "webhook-url|--set webhook.url=https://hooks.example.com"
   "ingress|--set ingress.enabled=true"
-  "s3|--set s3.enabled=true --set s3.storage.mode=s3 --set s3.bucket.name=b --set s3.bucket.region=us-east-1 --set s3.auth.accessKeyId=A --set s3.auth.secretAccessKey=S"
+  "s3|--set s3.enabled=true --set s3.storage.mode=s3 --set s3.bucket.name=b --set s3.bucket.region=us-east-1 --set s3.auth.accessKeyId=A --set s3.auth.secretAccessKeySecret.name=s3-creds --set s3.auth.secretAccessKeySecret.key=secretKey"
   "queue-all-tiers|--set webhook.url=https://hooks.example.com --set redis.enabled=true --set worker.enabled=true --set webhookProcessor.enabled=true"
 )
 
@@ -43,8 +43,13 @@ for scenario in "${SCENARIOS[@]}"; do
   fi
 
   for var in "${DEPRECATED[@]}"; do
-    # Word-boundary match, so N8N_WEBHOOK_URL does not match WEBHOOK_URL.
-    if echo "$out" | grep -qE "(^|[^A-Z0-9_])${var}([^A-Z0-9_]|$)"; then
+    # Match only the positions where the chart can emit an env var name: an
+    # env entry ("name: VAR"), a configMapKeyRef ("key: VAR"), or a ConfigMap
+    # data key ("VAR:" at the start of a line). Values never match, so a URL
+    # containing the deprecated name cannot false-positive, and N8N_WEBHOOK_URL
+    # does not match WEBHOOK_URL. Here-string, not a pipe: with pipefail, grep
+    # -q exiting early can SIGPIPE the writer and turn a hit into a miss.
+    if grep -qE "((name|key): ${var}$)|(^[[:space:]]*${var}:)" <<< "$out"; then
       echo "FAIL [$name] chart renders deprecated env var: $var"
       rc=1
     fi


### PR DESCRIPTION

## Description

`N8N_AVAILABLE_BINARY_DATA_MODES` is deprecated with no replacement. n8n files
it under the `SAFE_TO_REMOVE` constant (`deprecation.service.ts:28`, entry at
`:41`): "Remove this environment variable; it is no longer needed."

The chart sets it unconditionally inside the `n8n.s3Env` helper, so any
deployment with `s3.enabled: true` logs the warning on startup. Scoped to S3
mode rather than every deployment.

Verified against chart `v1.11.0` and `n8n@2.36.0`.

The template fix is one line. The rest of the diff is because `availableModes`
turns up in five places, not one:

| File | Role |
| --- | --- |
| `templates/_environment-helpers.tpl:10` | the only consumer |
| `values.yaml:681` | default |
| `values.schema.json:696` | schema property |
| `examples/production-s3.yaml:80` | example |
| `examples/multi-main-queue.yaml:67` | example |

Removing the only consumer and leaving the rest would be the worst option: lint
still passes, the schema still advertises the knob, the examples still set it,
and users keep configuring something that does nothing.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Example/configuration update
- [ ] CI/CD improvements

## Related Issues

Relates to # (n8n deprecation warnings under chart v1.11.0)

## Changes Made

- `templates/_environment-helpers.tpl`: removed the `N8N_AVAILABLE_BINARY_DATA_MODES` env var from `n8n.s3Env`
- `values.yaml`: removed `s3.storage.availableModes` and its comment
- `values.schema.json`: removed the `availableModes` property
- `examples/production-s3.yaml` and `examples/multi-main-queue.yaml`: removed the now-dead setting
- `scripts/check-deprecated-env.sh` (new) + a `ci.yml` step: renders the chart with `s3.enabled=true` and fails the build if `N8N_AVAILABLE_BINARY_DATA_MODES` reappears

### The diff

`charts/n8n/templates/_environment-helpers.tpl`, the actual fix:

```diff
@@ -4,8 +4,6 @@
 {{- define "n8n.s3Env" -}}
 {{- if .Values.s3.enabled }}
 # S3 External Storage Configuration
 - name: N8N_DEFAULT_BINARY_DATA_MODE
   value: {{ .Values.s3.storage.mode | quote }}
-- name: N8N_AVAILABLE_BINARY_DATA_MODES
-  value: {{ .Values.s3.storage.availableModes | quote }}
 - name: N8N_EXTERNAL_STORAGE_S3_BUCKET_NAME
   value: {{ .Values.s3.bucket.name | quote }}
```

`charts/n8n/values.yaml` ~680:

```diff
   storage:
     # Binary data storage mode (filesystem or s3 (filesystem))
     mode: "filesystem"
-    # Available binary data modes (comma-separated ex: filesystem,s3)
-    availableModes: "filesystem"              # <-- Available storage modes for n8n
     # S3 specific settings
     forcePathStyle: false                      # <-- Force path-style URLs (for S3-compatible providers)
```

`charts/n8n/values.schema.json` ~696:

```diff
             "mode": { 
               "type": "string",
               "enum": ["filesystem", "s3"],
               "description": "Binary data storage mode"
             },
-            "availableModes": {
-              "type": "string",
-              "description": "Available binary data modes (comma-separated)"
-            },
             "forcePathStyle": { "type": "boolean" },
```

`charts/n8n/examples/production-s3.yaml` ~80 and
`charts/n8n/examples/multi-main-queue.yaml` ~67, same line in both:

```diff
   storage:
     mode: "s3"
-    availableModes: "filesystem,s3"
```

`scripts/check-deprecated-env.sh` (new), wired into the `lint` job right after `ct lint`. Render-only, no cluster or licence needed:

```bash
DEPRECATED=(
  "N8N_AVAILABLE_BINARY_DATA_MODES"
)

SCENARIOS=(
  "s3|--set s3.enabled=true --set s3.storage.mode=s3 --set s3.bucket.name=b --set s3.bucket.region=us-east-1 --set s3.auth.accessKeyId=A --set s3.auth.secretAccessKeySecret.name=s3-creds --set s3.auth.secretAccessKeySecret.key=secretKey"
)
```

## Testing Performed

### Chart Validation

- [x] `helm lint charts/n8n` passes (helm v4.2.3, 1 chart linted, 0 failed)
- [x] `ct lint --chart-dirs charts --charts charts/n8n --validate-maintainers=false` passes (ct 3.14.0)
- [x] Template rendering works with all examples (10/10 render, matching the `ci.yml` matrix)

### Deployment Testing

- [x] Tested with minimal configuration
- [x] Tested with production configuration (S3 enabled)
- [x] Tested upgrade path from previous version (upgraded in place from unpatched `main`)
- [x] All pods start successfully (non-S3 install)
- [x] Application is accessible (`helm test n8n` passes)

Run locally on kind v0.32.0 (k8s v1.36.1) following the same sequence as the
`install-test` job. n8n image `stable`, resolved to 2.36.7.

### Runtime proof, with a control

Installed with S3 enabled on unpatched `main`, then upgraded the same release
onto this branch with identical values.

Before, on `main`:

```
 - N8N_AVAILABLE_BINARY_DATA_MODES -> Remove this environment variable; it is no longer needed.
```

After, on this branch, that line is gone and only the four unset-variable
deprecations remain. Env vars on the pod confirm the rest of the S3 block is
untouched:

```
N8N_DEFAULT_BINARY_DATA_MODE
N8N_EXTERNAL_STORAGE_S3_BUCKET_NAME
N8N_EXTERNAL_STORAGE_S3_BUCKET_REGION
N8N_EXTERNAL_STORAGE_S3_ACCESS_KEY
N8N_EXTERNAL_STORAGE_S3_ACCESS_SECRET
```

One note on the S3 pod: it crash-loops in this test environment with "S3 binary
data storage requires a valid license". That is n8n gating the feature behind a
licence, unrelated to this change, and it happens identically on `main`. The
deprecation output and the env block are both emitted before that point.

### Guard revert test

Checked the guard actually goes red on the bug it exists to catch, not just that it passes on a clean tree. Restored `_environment-helpers.tpl` from `main` onto this branch:

```
FAIL: s3 still renders N8N_AVAILABLE_BINARY_DATA_MODES
exit 1
```

Restored the fix, ran again:

```
PASS
exit 0
```

### Specific Testing for Changes

Note the chart requires an encryption key and S3 credentials, otherwise
templating fails before it reaches anything relevant.

```bash
# deprecated var gone from S3 mode
helm template n8n ./charts/n8n \
  --set secretRefs.env.N8N_ENCRYPTION_KEY=testkey1234567890 \
  --set s3.enabled=true --set s3.storage.mode=s3 \
  --set s3.bucket.name=my-bucket --set s3.bucket.region=us-east-1 \
  --set s3.auth.accessKeyId=AKIAtest --set s3.auth.secretAccessKey=secrettest \
  | grep -c AVAILABLE_BINARY_DATA_MODES
# result: 0

# rest of the S3 block intact
# result: N8N_DEFAULT_BINARY_DATA_MODE, N8N_EXTERNAL_STORAGE_S3_ACCESS_KEY,
#         N8N_EXTERNAL_STORAGE_S3_BUCKET_NAME, N8N_EXTERNAL_STORAGE_S3_BUCKET_REGION
#         all still present

# non-S3 deployments unaffected
helm template n8n ./charts/n8n \
  --set secretRefs.env.N8N_ENCRYPTION_KEY=testkey1234567890 \
  --set s3.enabled=false | grep -c BINARY_DATA
# result: 0

# every bundled example still renders
for f in charts/n8n/examples/*.yaml; do
  helm template test charts/n8n -f "$f" \
    --set secretRefs.env.N8N_ENCRYPTION_KEY=testkey1234567890 \
    --dry-run=client > /dev/null 2>&1 && echo "ok $f" || echo "FAIL $f"
done
# result: 10 ok, 0 failed
```

## Breaking Changes

None.

Removing the property from `values.schema.json` does **not** cause existing
values files to fail validation. The schema sets no `additionalProperties:
false` on `s3.storage`, `s3`, or the root, and the root is explicitly
`additionalProperties: true`, so unknown keys are permitted by design.

Verified rather than assumed: a values file that still sets
`s3.storage.availableModes` renders successfully against the patched chart.

The practical effect for anyone still setting it is nil. The value already fed
only a variable n8n ignores, so it was inert before this PR and is inert after.
Removing it from `values.yaml` and the schema just stops the chart advertising
a knob that does nothing.

## Documentation Updates

- [ ] Updated Chart.yaml version (CONTRIBUTING says not to, release-please handles it)
- [ ] Updated CHANGELOG.md
- [ ] Updated README.md (no mention of `availableModes`, checked)
- [x] Updated examples (both S3 examples updated in this PR)
- [ ] Updated CONTRIBUTING.md (not needed)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added examples that demonstrate the changes (both S3 examples updated)
- [x] All new and existing tests pass (lint plus the full example matrix)

## Additional Notes

`ci.yml` renders every file under `charts/n8n/examples/` in a matrix, so a
schema change that left an example behind would fail CI. Both examples are
updated here, so schema and examples stay in step.

There's a companion PR renaming `WEBHOOK_URL` to `N8N_WEBHOOK_URL` (#184). Both add
`scripts/check-deprecated-env.sh`, each scoped to the one variable it fixes, since a
combined list would fail on whichever bug the other PR hasn't merged yet. Whichever
merges second gets a one-line add/add conflict on that script; the fix is to union
the `DEPRECATED` array. Confirmed by merging both branches locally, the guard passes
clean with both variables listed.
