### PR TITLE
fix: repair the raw Kubernetes manifests (n8n OOM on startup, Postgres restart on first deploy)

### DIFF
--- a/kubernetes/n8n-deployment.yaml
+++ b/kubernetes/n8n-deployment.yaml
@@ -53,15 +53,15 @@ spec:
               value: http
             - name: N8N_PORT
               value: "5678"
-          image: n8nio/n8n
+          image: n8nio/n8n:2.23.4
           name: n8n
           ports:
             - containerPort: 5678
           resources:
             requests:
-              memory: "250Mi"
+              memory: "512Mi"
             limits:
-              memory: "500Mi"
+              memory: "1Gi"
           volumeMounts:
             - mountPath: /home/node/.n8n
               name: n8n-claim0

--- a/kubernetes/n8n-deployment.yaml
+++ b/kubernetes/n8n-deployment.yaml
@@ -53,7 +53,7 @@ spec:
               value: http
             - name: N8N_PORT
               value: "5678"
-          image: n8nio/n8n:2.23.4
+          image: n8nio/n8n
           name: n8n
           ports:
             - containerPort: 5678

--- a/kubernetes/postgres-configmap.yaml
+++ b/kubernetes/postgres-configmap.yaml
@@ -8,16 +8,12 @@ data:
     #!/bin/bash
     set -e;
     if [ -n "${POSTGRES_NON_ROOT_USER:-}" ] && [ -n "${POSTGRES_NON_ROOT_PASSWORD:-}" ]; then
-    	psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
-    		DO \$\$
-    		BEGIN
-    		IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '${POSTGRES_NON_ROOT_USER}') THEN
-    		CREATE USER "${POSTGRES_NON_ROOT_USER}" WITH PASSWORD '${POSTGRES_NON_ROOT_PASSWORD}';
-    		END IF;
-    		END
-    		\$\$;
-    		GRANT ALL PRIVILEGES ON DATABASE ${POSTGRES_DB} TO "${POSTGRES_NON_ROOT_USER}";
-    		GRANT ALL ON SCHEMA public TO "${POSTGRES_NON_ROOT_USER}";
+    	psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" \
+    		-v n8n_user="$POSTGRES_NON_ROOT_USER" -v n8n_password="$POSTGRES_NON_ROOT_PASSWORD" -v n8n_db="$POSTGRES_DB" <<-'EOSQL'
+    		SELECT format('CREATE USER %I', :'n8n_user') WHERE NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = :'n8n_user') \gexec
+    		SELECT format('ALTER ROLE %I WITH LOGIN PASSWORD %L', :'n8n_user', :'n8n_password') \gexec
+    		SELECT format('GRANT ALL PRIVILEGES ON DATABASE %I TO %I', :'n8n_db', :'n8n_user') \gexec
+    		SELECT format('GRANT ALL ON SCHEMA public TO %I', :'n8n_user') \gexec
     	EOSQL
     else
     	echo "SETUP INFO: No Environment variables given!"

--- a/kubernetes/postgres-configmap.yaml
+++ b/kubernetes/postgres-configmap.yaml
@@ -11,7 +11,7 @@ data:
     	psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" \
     		-v n8n_user="$POSTGRES_NON_ROOT_USER" -v n8n_password="$POSTGRES_NON_ROOT_PASSWORD" -v n8n_db="$POSTGRES_DB" <<-'EOSQL'
     		SELECT format('CREATE USER %I', :'n8n_user') WHERE NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = :'n8n_user') \gexec
-    		SELECT format('ALTER ROLE %I WITH LOGIN PASSWORD %L', :'n8n_user', :'n8n_password') \gexec
+    		SELECT format('ALTER ROLE %I WITH LOGIN PASSWORD %L', :'n8n_user', :'n8n_password') WHERE :'n8n_user' <> current_user \gexec
     		SELECT format('GRANT ALL PRIVILEGES ON DATABASE %I TO %I', :'n8n_db', :'n8n_user') \gexec
     		SELECT format('GRANT ALL ON SCHEMA public TO %I', :'n8n_user') \gexec
     	EOSQL

--- a/kubernetes/postgres-configmap.yaml
+++ b/kubernetes/postgres-configmap.yaml
@@ -9,7 +9,13 @@ data:
     set -e;
     if [ -n "${POSTGRES_NON_ROOT_USER:-}" ] && [ -n "${POSTGRES_NON_ROOT_PASSWORD:-}" ]; then
     	psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+    		DO \$\$
+    		BEGIN
+    		IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '${POSTGRES_NON_ROOT_USER}') THEN
     		CREATE USER "${POSTGRES_NON_ROOT_USER}" WITH PASSWORD '${POSTGRES_NON_ROOT_PASSWORD}';
+    		END IF;
+    		END
+    		\$\$;
     		GRANT ALL PRIVILEGES ON DATABASE ${POSTGRES_DB} TO "${POSTGRES_NON_ROOT_USER}";
     		GRANT ALL ON SCHEMA public TO "${POSTGRES_NON_ROOT_USER}";
     	EOSQL

--- a/kubernetes/postgres-secret.yaml
+++ b/kubernetes/postgres-secret.yaml
@@ -8,5 +8,5 @@ stringData:
   POSTGRES_USER: changeUser
   POSTGRES_PASSWORD: changePassword
   POSTGRES_DB: n8n
-  POSTGRES_NON_ROOT_USER: changeUser
-  POSTGRES_NON_ROOT_PASSWORD: changePassword
+  POSTGRES_NON_ROOT_USER: changeNonRootUser
+  POSTGRES_NON_ROOT_PASSWORD: changeNonRootPassword


### PR DESCRIPTION
## Summary

The raw Kubernetes manifests under `kubernetes/` (the ones the AWS/Azure/GKE tutorials tell people to `git clone` and apply) fail on a fresh cluster in two ways. Both are pre-existing and independent of the recent Postgres-18 change. Fixes here bring `kubectl apply -f .` up cleanly.

### 1. n8n crash-loops with a JS heap OOM on startup

`n8n-deployment.yaml` capped memory at `500Mi`. Current n8n exceeds that during startup (right after DB migrations) and dies with `Ineffective mark-compacts near heap limit / JavaScript heap out of memory`, so the pod crash-loops and the editor never loads.

- Raise `limits.memory` to `1Gi` (verified to boot: `/healthz` returns ok, editor returns 200) and `requests.memory` to `512Mi`.
- The image stays `n8nio/n8n` (unpinned) for now. Tag pinning is being handled separately.

### 2. Postgres restarts once on every first deploy

`postgres-secret.yaml` shipped the same placeholder (`changeUser`) for both `POSTGRES_USER` and `POSTGRES_NON_ROOT_USER`. The entrypoint creates the superuser, then `init-data.sh` tries to create the non-root user, which already exists → `role "changeUser" already exists` → the init script exits non-zero → the container restarts once. Cosmetic (it recovers on the second boot) but alarming, and the non-root user never gets created.

- Give the two users distinct placeholders (`changeUser` / `changeNonRootUser`), and likewise for the passwords.
- Harden `init-data.sh`: create the role only when it does not exist, then set `LOGIN` and the declared password on it, unless it is the role the script is connected as (the superuser). A configuration that points both users at the same value therefore neither errors nor rewrites the superuser password. The role name, password and database reach psql as variables and every statement is built with `format()`, so a quote or other special character in a secret value cannot break the SQL.

## Verification

- Fix 1 memory value is the ticket's live-confirmed floor (`1Gi` boots cleanly).
- Fix 2 init script verified against `postgres:18` in Docker (the script mounted as an initdb script, exactly as the deployment does), with logins checked over the network with SCRAM: the new distinct-user defaults create the non-root user, which can log in and create tables; a role name and password that both contain a single quote complete with no errors and no restart; the original same-user configuration completes with no error and no restart, and the superuser keeps `POSTGRES_PASSWORD` even when the non-root password differs; empty variables hit the "No Environment variables given" branch.
- Note: repo CI only lints the Helm chart, not these raw manifests, so there's no automated coverage for either regression. A kind-based smoke test that applies `kubernetes/` and waits for `/healthz` would have caught both: recommended as a follow-up.

Fixes [ENT-373](https://linear.app/n8n/issue/ENT-373).
