### PR TITLE
ci: register the preview chart publish so it can be dispatched

### DIFF
--- a/.github/workflows/preview-chart.yml
+++ b/.github/workflows/preview-chart.yml
@@ -50,7 +50,7 @@ jobs:
           BUILD: ${{ inputs.build }}
         run: |
           set -euo pipefail
-          if ! [[ "$BUILD" =~ ^[0-9]+$ ]]; then
+          if ! [[ "$BUILD" =~ ^[1-9][0-9]*$ ]]; then
             echo "::error::build must be a positive integer, got '$BUILD'"
             exit 1
           fi

--- a/.github/workflows/preview-chart.yml
+++ b/.github/workflows/preview-chart.yml
@@ -1,0 +1,106 @@
+# Publishes a one-off preview chart from the preview/worker-pools branch.
+#
+# Manual only, and never on a release path: release.yml runs release-please on
+# pushes to main and is untouched by this branch, so nothing here can cut a
+# real release or move the chart's version.
+#
+# The published version is the chart's current version with a prerelease
+# suffix, e.g. 1.11.0-preview.workerpools.1. Helm ignores prerelease versions
+# unless the caller passes --devel or names the version exactly, so a customer
+# running `helm install ... --version 1.11.x` will not pick this up.
+name: Preview chart
+
+on:
+  workflow_dispatch:
+    inputs:
+      build:
+        description: "Build number for this preview (1, 2, 3, ...). Bump it for every publish; pushing an existing version fails."
+        required: true
+        default: "1"
+      repository:
+        description: "OCI repository to push to."
+        required: true
+        default: "oci://ghcr.io/n8n-io/n8n-helm-chart"
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: preview-chart
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    # Only ever from the preview branch. workflow_dispatch lets the caller pick
+    # any ref, and a preview chart built from main would be a released chart
+    # wearing a preview version.
+    if: github.ref == 'refs/heads/preview/worker-pools'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: azure/setup-helm@v4
+        with:
+          version: "3.17.0"
+
+      - name: Resolve preview version
+        id: version
+        env:
+          BUILD: ${{ inputs.build }}
+        run: |
+          set -euo pipefail
+          if ! [[ "$BUILD" =~ ^[0-9]+$ ]]; then
+            echo "::error::build must be a positive integer, got '$BUILD'"
+            exit 1
+          fi
+          BASE=$(helm show chart charts/n8n | awk '$1=="version:"{print $2}')
+          if [[ "$BASE" == *-* ]]; then
+            echo "::error::chart version '$BASE' is already a prerelease; expected a plain release version"
+            exit 1
+          fi
+          echo "version=${BASE}-preview.workerpools.${BUILD}" >> "$GITHUB_OUTPUT"
+
+      - name: Lint and render
+        run: |
+          set -euo pipefail
+          helm lint charts/n8n
+          for f in charts/n8n/examples/*.yaml; do
+            helm template preview charts/n8n -f "$f" --dry-run=client > /dev/null
+          done
+          helm template preview charts/n8n \
+            -f charts/n8n/examples/minimal.yaml \
+            -f charts/n8n/ci/workerGroups-values.yaml --dry-run=client > /dev/null
+
+      - name: Log in to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | \
+            helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Package and push
+        env:
+          CHART_VERSION: ${{ steps.version.outputs.version }}
+          OCI_REPOSITORY: ${{ inputs.repository }}
+        run: |
+          set -euo pipefail
+          helm package charts/n8n --version "$CHART_VERSION" --destination /tmp/chart-pkg/
+          helm push "/tmp/chart-pkg/n8n-${CHART_VERSION}.tgz" "$OCI_REPOSITORY"
+
+      - name: Summary
+        env:
+          CHART_VERSION: ${{ steps.version.outputs.version }}
+          OCI_REPOSITORY: ${{ inputs.repository }}
+        run: |
+          {
+            echo "### Preview chart published"
+            echo
+            echo "\`${CHART_VERSION}\` from \`${GITHUB_SHA:0:7}\`"
+            echo
+            echo "Worker pools are an experimental n8n feature and need n8n 2.39.0 or newer."
+            echo
+            echo '```'
+            echo "helm install n8n ${OCI_REPOSITORY}/n8n \\"
+            echo "  --version ${CHART_VERSION} \\"
+            echo "  -f worker-pools.yaml"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Description

We're putting the worker pools chart support on a dedicated `preview/worker-pools` branch rather than into the released chart, so we can get allow users to preview it without anyone accidentally depending on it. 

That branch carries `preview-chart.yml`, a manual publish that packages the chart as a prerelease version and pushes it to GHCR. GitHub only registers a `workflow_dispatch` workflow if the file is present on the default branch, though. You choose the ref to run against afterwards, but the workflow has to exist on `main` to appear in the Actions list at all, so without this copy there is no way to cut a preview chart short of packaging it by hand.

The copy that actually executes is the one on `preview/worker-pools`. This one is identical, which keeps the registered definition and the executed one from drifting apart.

## Why it is safe on main

The job is gated on the branch:

```yaml
if: github.ref == 'refs/heads/preview/worker-pools'
```

Dispatching it from `main` does nothing. It also only ever publishes prerelease versions (`1.11.0-preview.workerpools.N`), which Helm will not select without `--devel` or an exact `--version`.

`release.yml` is untouched and unaffected. It fires on pushes to `main` filtered to `charts/**`, `CHANGELOG.md`, the release-please files and `.github/workflows/release.yml`, and this matches none of them, so merging will not open a release PR.


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Example/configuration update
- [x] CI/CD improvements

## Related Issues

[DEP-5](https://linear.app/n8n/issue/DEP-5/register-preview-chartyml-on-main-so-it-can-be-dispatched), a sub-task of [DEP-4](https://linear.app/n8n/issue/DEP-4/ship-worker-pools-chart-support-on-a-preview-branch).

## Testing Performed

The file is byte-identical to the copy on `preview/worker-pools`, where CI already passes. On that branch I checked the version resolution against the real chart: it reads `1.11.0` from `Chart.yaml` and packages `n8n-1.11.0-preview.workerpools.1.tgz` cleanly.

Confirming the registration gap is the point of this PR, so that part is only verifiable once it merges. Today `repos/n8n-io/n8n-hosting/actions/workflows` lists CI, Release and the two Copilot entries, and the file 404s on `ref=main`. After merge it should appear in the Actions list and be dispatchable against `preview/worker-pools`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n-hosting/pull/191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

