### PR TITLE
feat(aws-cloudformation): bring the ECS Fargate templates up to n8n 2.38.5

### DIFF
--- a/aws-cloudformation/ecs-fargate/README.md
+++ b/aws-cloudformation/ecs-fargate/README.md
@@ -43,6 +43,8 @@ Before deploying, provide:
 - An ACM certificate ARN in the same AWS Region as the stack.
 - Production-grade database, Redis, license, and password values.
 
+`N8nVersion` sets the n8n version to deploy. The default tracks `appVersion` in `charts/n8n/Chart.yaml`, currently `2.38.5`, so every artefact in this repository points at one n8n version. On the `-webhooks` and `-ha` templates it drives both the `n8nio/n8n` and `n8nio/runners` images, which are released together, so the two can never drift apart. Only concrete versions are accepted, `stable` and `latest` are rejected by the parameter's own pattern.
+
 The template includes placeholder defaults for some secrets so it is easy to inspect, but those values should be replaced before using the stack for a real deployment.
 
 ## Worker Scaling
@@ -107,9 +109,11 @@ For production changes, create and review a CloudFormation change set in a non-p
 
 ## Upgrading existing stacks
 
-The templates pin the database engine and the n8n image directly in the resource definitions (they are not stack parameters), so new stacks deploy on known-good versions. If you are updating a stack created from an earlier version of the base template, review the change set first, these pins can force a modify or a downgrade:
+The templates pin the database engine directly in the resource definitions (it is not a stack parameter) and the n8n image through the `N8nVersion` parameter, so new stacks deploy on known-good versions. If you are updating a stack created from an earlier version of the base template, review the change set first, these pins can force a modify or a downgrade:
 
 - **RDS / Aurora `EngineVersion` `16.x` -> `18.4`**: a **major** engine upgrade, so follow the AWS guide, [RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.PostgreSQL.html) or [Aurora](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_UpgradeDBInstance.PostgreSQL.html) for the HA tier. `16.9` upgrades directly to `18.4` on both, no intermediate version. Two things that guide cannot tell you: `EngineVersion` is a hardcoded property here rather than a stack parameter, so edit it in the template before deploying the change set, and CloudFormation cannot apply a version below the one the instance is already on, so if `AutoMinorVersionUpgrade` moved it past the pin the update rolls back. To stay put, pin `17.x` or `16.x`, both are within n8n's compatibility range.
-- **n8n image `latest` -> a pinned tag**: the image tag is likewise hardcoded in the container definitions, not a parameter. A stack that already pulled a newer n8n and ran its database migrations will crash-loop if the pin resolves to an older image, because n8n does not down-migrate the schema. Edit the tag to the version currently running (or newer), never older.
+- **n8n image `latest` -> a pinned version**: the image tag comes from the `N8nVersion` parameter. A stack that already pulled a newer n8n and ran its database migrations will crash-loop if the version resolves to an older image, because n8n does not down-migrate the schema. Pass `N8nVersion` set to the version currently running (or newer), never older.
+
+  Because it is a parameter, an existing stack keeps whatever value it already holds: a console update, or `--use-previous-value`, retains it, so a newer default in this repository does not move a running stack on its own. That is deliberate, no stack changes n8n version unless you ask it to, but it does mean upgrading is an explicit act. Pass the parameter, or set it in the console, to move.
 
 New stacks are unaffected, they start directly on the pinned versions.

--- a/aws-cloudformation/ecs-fargate/README.md
+++ b/aws-cloudformation/ecs-fargate/README.md
@@ -43,7 +43,7 @@ Before deploying, provide:
 - An ACM certificate ARN in the same AWS Region as the stack.
 - Production-grade database, Redis, license, and password values.
 
-`N8nVersion` sets the n8n version to deploy. The default tracks `appVersion` in `charts/n8n/Chart.yaml`, currently `2.38.5`, so every artefact in this repository points at one n8n version. On the `-webhooks` and `-ha` templates it drives both the `n8nio/n8n` and `n8nio/runners` images, which are released together, so the two can never drift apart. Only concrete versions are accepted, `stable` and `latest` are rejected by the parameter's own pattern.
+`N8nVersion` sets the n8n version to deploy, and defaults to a concrete version, currently `2.38.5`, rather than a floating tag. On the `-webhooks` and `-ha` templates it drives both the `n8nio/n8n` and `n8nio/runners` images, which are released together, so the two can never drift apart. Only concrete versions are accepted, `stable` and `latest` are rejected by the parameter's own pattern.
 
 The template includes placeholder defaults for some secrets so it is easy to inspect, but those values should be replaced before using the stack for a real deployment.
 
@@ -114,6 +114,8 @@ The templates pin the database engine directly in the resource definitions (it i
 - **RDS / Aurora `EngineVersion` `16.x` -> `18.4`**: a **major** engine upgrade, so follow the AWS guide, [RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.PostgreSQL.html) or [Aurora](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_UpgradeDBInstance.PostgreSQL.html) for the HA tier. `16.9` upgrades directly to `18.4` on both, no intermediate version. Two things that guide cannot tell you: `EngineVersion` is a hardcoded property here rather than a stack parameter, so edit it in the template before deploying the change set, and CloudFormation cannot apply a version below the one the instance is already on, so if `AutoMinorVersionUpgrade` moved it past the pin the update rolls back. To stay put, pin `17.x` or `16.x`, both are within n8n's compatibility range.
 - **n8n image `latest` -> a pinned version**: the image tag comes from the `N8nVersion` parameter. A stack that already pulled a newer n8n and ran its database migrations will crash-loop if the version resolves to an older image, because n8n does not down-migrate the schema. Pass `N8nVersion` set to the version currently running (or newer), never older.
 
-  Because it is a parameter, an existing stack keeps whatever value it already holds: a console update, or `--use-previous-value`, retains it, so a newer default in this repository does not move a running stack on its own. That is deliberate, no stack changes n8n version unless you ask it to, but it does mean upgrading is an explicit act. Pass the parameter, or set it in the console, to move.
+  The first update is the exception. A stack created before `N8nVersion` existed has no stored value for it, so CloudFormation applies the default and moves the stack to that version, exactly as taking a newer template did when the tag was hardcoded. If you need to stay where you are, pass `N8nVersion` explicitly on that update, and review the change set as above.
+
+  After that the stack keeps whatever value it holds: a console update, or `--use-previous-value`, retains it, so a newer default in this repository does not move a running stack on its own. That is deliberate, no stack changes n8n version unless you ask it to, but it does mean upgrading is an explicit act. Pass the parameter, or set it in the console, to move.
 
 New stacks are unaffected, they start directly on the pinned versions.

--- a/aws-cloudformation/ecs-fargate/n8n-w-multimain-queuemode-webhooks-ha.yaml
+++ b/aws-cloudformation/ecs-fargate/n8n-w-multimain-queuemode-webhooks-ha.yaml
@@ -6,6 +6,15 @@ Description: >-
 
 Parameters:
 
+# n8n image parameters
+
+  N8nVersion:
+    Type: String
+    Default: "2.38.5"
+    Description: "n8n version to deploy. Drives both the n8nio/n8n and n8nio/runners images, which are released together and must match. Never move this below the version a running stack has already migrated to, n8n does not down-migrate the schema."
+    AllowedPattern: '^[0-9]+\.[0-9]+\.[0-9]+$'
+    ConstraintDescription: "Must be a concrete n8n version such as 2.38.5, not a floating tag like stable or latest."
+
 # n8n host parameters
 
   N8nHostedZone:
@@ -196,6 +205,10 @@ Parameters:
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
+      - Label:
+          default: "n8n Image Config"
+        Parameters:
+          - N8nVersion
       - Label:
           default: "n8n License Config"
         Parameters:
@@ -1155,7 +1168,7 @@ Resources:
         - Name: runner-cfg
       ContainerDefinitions:
         - Name: n8n
-          Image: n8nio/n8n:2.23.4
+          Image: !Sub "n8nio/n8n:${N8nVersion}"
           Essential: true
           StopTimeout: 120
           PortMappings:
@@ -1317,7 +1330,7 @@ Resources:
         - !If
           - PythonRunner
           - Name: runner-config-init
-            Image: n8nio/runners:2.23.4
+            Image: !Sub "n8nio/runners:${N8nVersion}"
             Essential: false
             User: "0"
             EntryPoint: [ "/opt/runners/task-runner-python/.venv/bin/python", "-c" ]
@@ -1341,7 +1354,7 @@ Resources:
         - !If
           - PythonRunner
           - Name: task-runner
-            Image: n8nio/runners:2.23.4
+            Image: !Sub "n8nio/runners:${N8nVersion}"
             Essential: false
             Command: [ "javascript", "python" ]
             DependsOn:
@@ -1432,7 +1445,7 @@ Resources:
         - Name: runner-cfg
       ContainerDefinitions:
         - Name: n8n
-          Image: n8nio/n8n:2.23.4
+          Image: !Sub "n8nio/n8n:${N8nVersion}"
           Essential: true
           StopTimeout: 120
           PortMappings:
@@ -1585,7 +1598,7 @@ Resources:
         - !If
           - PythonRunner
           - Name: runner-config-init
-            Image: n8nio/runners:2.23.4
+            Image: !Sub "n8nio/runners:${N8nVersion}"
             Essential: false
             User: "0"
             EntryPoint: [ "/opt/runners/task-runner-python/.venv/bin/python", "-c" ]
@@ -1609,7 +1622,7 @@ Resources:
         - !If
           - PythonRunner
           - Name: task-runner
-            Image: n8nio/runners:2.23.4
+            Image: !Sub "n8nio/runners:${N8nVersion}"
             Essential: false
             Command: [ "javascript", "python" ]
             DependsOn:
@@ -1898,7 +1911,7 @@ Resources:
         - Name: runner-cfg
       ContainerDefinitions:
         - Name: n8n
-          Image: n8nio/n8n:2.23.4
+          Image: !Sub "n8nio/n8n:${N8nVersion}"
           Essential: true
           StopTimeout: 120
           EntryPoint:

--- a/aws-cloudformation/ecs-fargate/n8n-w-multimain-queuemode-webhooks-ha.yaml
+++ b/aws-cloudformation/ecs-fargate/n8n-w-multimain-queuemode-webhooks-ha.yaml
@@ -1282,7 +1282,7 @@ Resources:
               Value: default
             - Name: OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS
               Value: true
-            - Name: WEBHOOK_URL
+            - Name: N8N_WEBHOOK_URL
               Value: !Sub "https://${N8nHostRecord}/"
 
           LogConfiguration:
@@ -1551,7 +1551,7 @@ Resources:
               Value: !GetAtt Redis.PrimaryEndPoint.Port  
             - Name: QUEUE_BULL_REDIS_USERNAME
               Value: default              
-            - Name: WEBHOOK_URL
+            - Name: N8N_WEBHOOK_URL
               Value: !Sub "https://${N8nHostRecord}/"
 
           LogConfiguration:
@@ -2002,7 +2002,7 @@ Resources:
               Value: !GetAtt Redis.PrimaryEndPoint.Port
             - Name: QUEUE_BULL_REDIS_USERNAME
               Value: default
-            - Name: WEBHOOK_URL
+            - Name: N8N_WEBHOOK_URL
               Value: !Sub "https://${N8nHostRecord}/"
 
           LogConfiguration:

--- a/aws-cloudformation/ecs-fargate/n8n-w-multimain-queuemode-webhooks-ha.yaml
+++ b/aws-cloudformation/ecs-fargate/n8n-w-multimain-queuemode-webhooks-ha.yaml
@@ -1241,6 +1241,9 @@ Resources:
               Value: !Ref S3BinaryBucket
             - Name: N8N_EXTERNAL_STORAGE_S3_BUCKET_REGION
               Value: !Ref AWS::Region
+            # n8n 2.38.0 aborts the startup S3 HeadBucket check at 10s; a cold NAT or VPC endpoint path can exceed that
+            - Name: N8N_EXTERNAL_STORAGE_S3_STARTUP_TIMEOUT_MS
+              Value: 30000
             - Name: EXECUTIONS_MODE
               Value: queue
             - Name: N8N_LOG_LEVEL
@@ -1529,6 +1532,9 @@ Resources:
               Value: !Ref S3BinaryBucket
             - Name: N8N_EXTERNAL_STORAGE_S3_BUCKET_REGION
               Value: !Ref AWS::Region
+            # n8n 2.38.0 aborts the startup S3 HeadBucket check at 10s; a cold NAT or VPC endpoint path can exceed that
+            - Name: N8N_EXTERNAL_STORAGE_S3_STARTUP_TIMEOUT_MS
+              Value: 30000
             - Name: EXECUTIONS_MODE
               Value: queue
             - Name: N8N_CONCURRENCY
@@ -1994,6 +2000,9 @@ Resources:
               Value: !Ref S3BinaryBucket
             - Name: N8N_EXTERNAL_STORAGE_S3_BUCKET_REGION
               Value: !Ref AWS::Region
+            # n8n 2.38.0 aborts the startup S3 HeadBucket check at 10s; a cold NAT or VPC endpoint path can exceed that
+            - Name: N8N_EXTERNAL_STORAGE_S3_STARTUP_TIMEOUT_MS
+              Value: 30000
             - Name: EXECUTIONS_MODE
               Value: queue
             - Name: N8N_LOG_LEVEL

--- a/aws-cloudformation/ecs-fargate/n8n-w-multimain-queuemode-webhooks-ha.yaml
+++ b/aws-cloudformation/ecs-fargate/n8n-w-multimain-queuemode-webhooks-ha.yaml
@@ -1356,6 +1356,9 @@ Resources:
           - Name: task-runner
             Image: !Sub "n8nio/runners:${N8nVersion}"
             Essential: false
+            # the launcher force-kills a runner at 50s (30s grace + 2x10s margin), so ECS's 30s
+            # default would cut a drain short; 90s clears it, within the n8n containers' 120s budget
+            StopTimeout: 90
             Command: [ "javascript", "python" ]
             DependsOn:
               - ContainerName: runner-config-init
@@ -1624,6 +1627,9 @@ Resources:
           - Name: task-runner
             Image: !Sub "n8nio/runners:${N8nVersion}"
             Essential: false
+            # the launcher force-kills a runner at 50s (30s grace + 2x10s margin), so ECS's 30s
+            # default would cut a drain short; 90s clears it, within the n8n containers' 120s budget
+            StopTimeout: 90
             Command: [ "javascript", "python" ]
             DependsOn:
               - ContainerName: runner-config-init

--- a/aws-cloudformation/ecs-fargate/n8n-w-multimain-queuemode-webhooks.yaml
+++ b/aws-cloudformation/ecs-fargate/n8n-w-multimain-queuemode-webhooks.yaml
@@ -1209,7 +1209,7 @@ Resources:
               Value: default
             - Name: OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS
               Value: true
-            - Name: WEBHOOK_URL
+            - Name: N8N_WEBHOOK_URL
               Value: !Sub "https://${N8nHostRecord}/"
 
           LogConfiguration:
@@ -1478,7 +1478,7 @@ Resources:
               Value: !GetAtt Redis.PrimaryEndPoint.Port  
             - Name: QUEUE_BULL_REDIS_USERNAME
               Value: default              
-            - Name: WEBHOOK_URL
+            - Name: N8N_WEBHOOK_URL
               Value: !Sub "https://${N8nHostRecord}/"
 
           LogConfiguration:
@@ -1929,7 +1929,7 @@ Resources:
               Value: !GetAtt Redis.PrimaryEndPoint.Port
             - Name: QUEUE_BULL_REDIS_USERNAME
               Value: default
-            - Name: WEBHOOK_URL
+            - Name: N8N_WEBHOOK_URL
               Value: !Sub "https://${N8nHostRecord}/"
 
           LogConfiguration:

--- a/aws-cloudformation/ecs-fargate/n8n-w-multimain-queuemode-webhooks.yaml
+++ b/aws-cloudformation/ecs-fargate/n8n-w-multimain-queuemode-webhooks.yaml
@@ -1168,6 +1168,9 @@ Resources:
               Value: !Ref S3BinaryBucket
             - Name: N8N_EXTERNAL_STORAGE_S3_BUCKET_REGION
               Value: !Ref AWS::Region
+            # n8n 2.38.0 aborts the startup S3 HeadBucket check at 10s; a cold NAT or VPC endpoint path can exceed that
+            - Name: N8N_EXTERNAL_STORAGE_S3_STARTUP_TIMEOUT_MS
+              Value: 30000
             - Name: EXECUTIONS_MODE
               Value: queue
             - Name: N8N_LOG_LEVEL
@@ -1456,6 +1459,9 @@ Resources:
               Value: !Ref S3BinaryBucket
             - Name: N8N_EXTERNAL_STORAGE_S3_BUCKET_REGION
               Value: !Ref AWS::Region
+            # n8n 2.38.0 aborts the startup S3 HeadBucket check at 10s; a cold NAT or VPC endpoint path can exceed that
+            - Name: N8N_EXTERNAL_STORAGE_S3_STARTUP_TIMEOUT_MS
+              Value: 30000
             - Name: EXECUTIONS_MODE
               Value: queue
             - Name: N8N_CONCURRENCY
@@ -1921,6 +1927,9 @@ Resources:
               Value: !Ref S3BinaryBucket
             - Name: N8N_EXTERNAL_STORAGE_S3_BUCKET_REGION
               Value: !Ref AWS::Region
+            # n8n 2.38.0 aborts the startup S3 HeadBucket check at 10s; a cold NAT or VPC endpoint path can exceed that
+            - Name: N8N_EXTERNAL_STORAGE_S3_STARTUP_TIMEOUT_MS
+              Value: 30000
             - Name: EXECUTIONS_MODE
               Value: queue
             - Name: N8N_LOG_LEVEL

--- a/aws-cloudformation/ecs-fargate/n8n-w-multimain-queuemode-webhooks.yaml
+++ b/aws-cloudformation/ecs-fargate/n8n-w-multimain-queuemode-webhooks.yaml
@@ -1283,6 +1283,9 @@ Resources:
           - Name: task-runner
             Image: !Sub "n8nio/runners:${N8nVersion}"
             Essential: false
+            # the launcher force-kills a runner at 50s (30s grace + 2x10s margin), so ECS's 30s
+            # default would cut a drain short; 90s clears it, within the n8n containers' 120s budget
+            StopTimeout: 90
             Command: [ "javascript", "python" ]
             DependsOn:
               - ContainerName: runner-config-init
@@ -1551,6 +1554,9 @@ Resources:
           - Name: task-runner
             Image: !Sub "n8nio/runners:${N8nVersion}"
             Essential: false
+            # the launcher force-kills a runner at 50s (30s grace + 2x10s margin), so ECS's 30s
+            # default would cut a drain short; 90s clears it, within the n8n containers' 120s budget
+            StopTimeout: 90
             Command: [ "javascript", "python" ]
             DependsOn:
               - ContainerName: runner-config-init

--- a/aws-cloudformation/ecs-fargate/n8n-w-multimain-queuemode-webhooks.yaml
+++ b/aws-cloudformation/ecs-fargate/n8n-w-multimain-queuemode-webhooks.yaml
@@ -3,6 +3,15 @@ Description: Deploys n8n with multi-main and queue mode configured. s3 is used f
 
 Parameters:
 
+# n8n image parameters
+
+  N8nVersion:
+    Type: String
+    Default: "2.38.5"
+    Description: "n8n version to deploy. Drives both the n8nio/n8n and n8nio/runners images, which are released together and must match. Never move this below the version a running stack has already migrated to, n8n does not down-migrate the schema."
+    AllowedPattern: '^[0-9]+\.[0-9]+\.[0-9]+$'
+    ConstraintDescription: "Must be a concrete n8n version such as 2.38.5, not a floating tag like stable or latest."
+
 # n8n host parameters
 
   N8nHostedZone:
@@ -199,6 +208,10 @@ Parameters:
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
+      - Label:
+          default: "n8n Image Config"
+        Parameters:
+          - N8nVersion
       - Label:
           default: "n8n License Config"
         Parameters:
@@ -1082,7 +1095,7 @@ Resources:
         - Name: runner-cfg
       ContainerDefinitions:
         - Name: n8n
-          Image: n8nio/n8n:2.23.4
+          Image: !Sub "n8nio/n8n:${N8nVersion}"
           Essential: true
           StopTimeout: 120
           PortMappings:
@@ -1244,7 +1257,7 @@ Resources:
         - !If
           - PythonRunner
           - Name: runner-config-init
-            Image: n8nio/runners:2.23.4
+            Image: !Sub "n8nio/runners:${N8nVersion}"
             Essential: false
             User: "0"
             EntryPoint: [ "/opt/runners/task-runner-python/.venv/bin/python", "-c" ]
@@ -1268,7 +1281,7 @@ Resources:
         - !If
           - PythonRunner
           - Name: task-runner
-            Image: n8nio/runners:2.23.4
+            Image: !Sub "n8nio/runners:${N8nVersion}"
             Essential: false
             Command: [ "javascript", "python" ]
             DependsOn:
@@ -1359,7 +1372,7 @@ Resources:
         - Name: runner-cfg
       ContainerDefinitions:
         - Name: n8n
-          Image: n8nio/n8n:2.23.4
+          Image: !Sub "n8nio/n8n:${N8nVersion}"
           Essential: true
           StopTimeout: 120
           PortMappings:
@@ -1512,7 +1525,7 @@ Resources:
         - !If
           - PythonRunner
           - Name: runner-config-init
-            Image: n8nio/runners:2.23.4
+            Image: !Sub "n8nio/runners:${N8nVersion}"
             Essential: false
             User: "0"
             EntryPoint: [ "/opt/runners/task-runner-python/.venv/bin/python", "-c" ]
@@ -1536,7 +1549,7 @@ Resources:
         - !If
           - PythonRunner
           - Name: task-runner
-            Image: n8nio/runners:2.23.4
+            Image: !Sub "n8nio/runners:${N8nVersion}"
             Essential: false
             Command: [ "javascript", "python" ]
             DependsOn:
@@ -1825,7 +1838,7 @@ Resources:
         - Name: runner-cfg
       ContainerDefinitions:
         - Name: n8n
-          Image: n8nio/n8n:2.23.4
+          Image: !Sub "n8nio/n8n:${N8nVersion}"
           Essential: true
           StopTimeout: 120
           EntryPoint:

--- a/aws-cloudformation/ecs-fargate/n8n-w-multimain-queuemode.yaml
+++ b/aws-cloudformation/ecs-fargate/n8n-w-multimain-queuemode.yaml
@@ -7,6 +7,15 @@ Description: >-
 
 Parameters:
 
+# n8n image parameters
+
+  N8nVersion:
+    Type: String
+    Default: "2.38.5"
+    Description: "n8n version to deploy. Never move this below the version a running stack has already migrated to, n8n does not down-migrate the schema."
+    AllowedPattern: '^[0-9]+\.[0-9]+\.[0-9]+$'
+    ConstraintDescription: "Must be a concrete n8n version such as 2.38.5, not a floating tag like stable or latest."
+
 # n8n host parameters
 
   N8nHostedZone:
@@ -186,6 +195,10 @@ Parameters:
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
+      - Label:
+          default: "n8n Image Config"
+        Parameters:
+          - N8nVersion
       - Label:
           default: "n8n License Config"
         Parameters:
@@ -1003,7 +1016,7 @@ Resources:
         - Name: certs
       ContainerDefinitions:
         - Name: n8n
-          Image: n8nio/n8n:2.23.4
+          Image: !Sub "n8nio/n8n:${N8nVersion}"
           Essential: true
           StopTimeout: 120
           PortMappings:
@@ -1202,7 +1215,7 @@ Resources:
         - Name: certs
       ContainerDefinitions:
         - Name: n8n
-          Image: n8nio/n8n:2.23.4
+          Image: !Sub "n8nio/n8n:${N8nVersion}"
           Essential: true
           StopTimeout: 120
           PortMappings:

--- a/aws-cloudformation/ecs-fargate/n8n-w-multimain-queuemode.yaml
+++ b/aws-cloudformation/ecs-fargate/n8n-w-multimain-queuemode.yaml
@@ -1089,6 +1089,9 @@ Resources:
               Value: !Ref S3BinaryBucket
             - Name: N8N_EXTERNAL_STORAGE_S3_BUCKET_REGION
               Value: !Ref AWS::Region
+            # n8n 2.38.0 aborts the startup S3 HeadBucket check at 10s; a cold NAT or VPC endpoint path can exceed that
+            - Name: N8N_EXTERNAL_STORAGE_S3_STARTUP_TIMEOUT_MS
+              Value: 30000
             - Name: EXECUTIONS_MODE
               Value: queue
             - Name: N8N_LOG_LEVEL
@@ -1298,6 +1301,9 @@ Resources:
               Value: !Ref S3BinaryBucket
             - Name: N8N_EXTERNAL_STORAGE_S3_BUCKET_REGION
               Value: !Ref AWS::Region
+            # n8n 2.38.0 aborts the startup S3 HeadBucket check at 10s; a cold NAT or VPC endpoint path can exceed that
+            - Name: N8N_EXTERNAL_STORAGE_S3_STARTUP_TIMEOUT_MS
+              Value: 30000
             - Name: EXECUTIONS_MODE
               Value: queue
             - Name: N8N_LOG_LEVEL

--- a/aws-cloudformation/ecs-fargate/n8n-w-multimain-queuemode.yaml
+++ b/aws-cloudformation/ecs-fargate/n8n-w-multimain-queuemode.yaml
@@ -1107,7 +1107,7 @@ Resources:
               Value: default
             - Name: OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS
               Value: true
-            - Name: WEBHOOK_URL
+            - Name: N8N_WEBHOOK_URL
               Value: !Sub "https://${N8nHostRecord}/"
 
           LogConfiguration:
@@ -1316,7 +1316,7 @@ Resources:
               Value: !GetAtt Redis.PrimaryEndPoint.Port  
             - Name: QUEUE_BULL_REDIS_USERNAME
               Value: default              
-            - Name: WEBHOOK_URL
+            - Name: N8N_WEBHOOK_URL
               Value: !Sub "https://${N8nHostRecord}/"
 
           LogConfiguration:


### PR DESCRIPTION
## Desciption

This brings the three ECS Fargate templates from n8n `2.23.4` to `2.38.5`, matching the version the rest of the repo pins, and makes the version a stack parameter to make future bumps tidier.

This is will be followed up by #195 to keep these current going forward.

### Additional Changes

Reading the n8n releases between `2.23.4` and `2.38.5` turned up three things the templates needed:

- `WEBHOOK_URL` became `N8N_WEBHOOK_URL` in `2.30.0`. The old name still works as a fallback, so nothing was broken, but every task logged a deprecation on start.
- The task runner sidecars had no `StopTimeout`, so ECS applied its 30s default. Since `2.29.0` the launcher force-kills a runner at 50s, so the container was being killed before it finished draining. They're on 90s now, within the n8n containers' existing 120s.
- `2.38.0` put a 10s timeout on the S3 `HeadBucket` check n8n runs at startup, and throws when it expires. At `2.23.4` that check just waited. All three templates run S3 binary data mode from private subnets, where a cold NAT or VPC endpoint path can take longer than that, so I've set it to 30s.

There are no formal breaking changes across the range, and the container contract is unchanged: same user, entrypoint, ports, health endpoints and runner handshake.

### Upgrading an existing stack

Because the version is a parameter rather than a literal, a stack keeps whatever value it already holds: a console update, or `--use-previous-value`, retains it. A newer default here won't move a running stack on its own, which is deliberate, but it does mean upgrading is now an explicit act. The README's upgrade section covers it.

### Testing

`cfn-lint` is clean on all three templates, on every commit in the branch.

The base template was also deployed and upgraded for real on ECS Fargate, in `eu-west-1`, in queue mode with two mains and a worker:

- Created from the template as it stands on `main`, with the tag hardcoded at `2.23.4`. Reached `CREATE_COMPLETE`, target group healthy, editor reachable over HTTPS. I then created an owner account and a workflow so the upgrade had real data to preserve.
- Updated to this branch's template with every existing parameter set to `UsePreviousValue` and `N8nVersion` deliberately not passed, which is how an existing stack picks the parameter up for the first time. CloudFormation applied the `2.38.5` default, as documented. The change set touched only the two task definitions and their services, nothing near the database, load balancer, Redis or network.
- `UPDATE_COMPLETE`. Both task definitions on `n8nio/n8n:2.38.5`, the app reporting `versionCli: 2.38.5`, services back to full count, target group healthy, and the workflow and owner account intact through the migrations.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n-hosting/pull/194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->