### PR TITLE
chore(no-release): throwaway, checking install-test fires on a release-please branch

### DIFF
--- a/.github/workflows/bump-n8n-version.yml
+++ b/.github/workflows/bump-n8n-version.yml
@@ -1,0 +1,235 @@
+# Opens the weekly n8n version bump PR.
+#
+# Every Wednesday this resolves what n8n's `stable` release points at and, if it
+# has moved, rewrites the nine version pins through scripts/bump-n8n-version.sh
+# and opens one auto-merging PR. Release-please then cuts the chart release from
+# the squashed commit, so the weekly chart release also picks up whatever chart
+# work merged during the week.
+#
+# The repo squashes with PR_TITLE and PR_BODY, so the PR title is the exact
+# conventional commit subject release-please parses for the chart increment, and
+# the PR body becomes the commit body on main. Both are kept accordingly.
+#
+# The job only ever moves forwards within the current n8n major. A rollback, or
+# crossing a major, is a hand-written PR calling the script directly.
+name: Bump n8n version
+
+on:
+  schedule:
+    # Wednesday 09:00 UTC, the day after the n8n release.
+    - cron: "0 9 * * 3"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "n8n version to bump to, for example 2.38.6. Leave empty to resolve stable."
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: bump-n8n-version
+  cancel-in-progress: false
+
+env:
+  BRANCH: automated/bump-n8n
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # The push below uses the App token, not this job's GITHUB_TOKEN, so
+          # there is nothing to gain from leaving credentials in the checkout.
+          persist-credentials: false
+
+      - name: Resolve current version
+        id: current
+        run: |
+          set -euo pipefail
+
+          # Only from the default branch. workflow_dispatch lets the caller pick
+          # any ref, and a bump PR built from an arbitrary branch's script is not
+          # something to hand auto-merge. Loud rather than a job-level `if`,
+          # which would skip a mistaken dispatch green and say nothing.
+          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
+            echo "::error::this job only runs from main, but $GITHUB_REF was dispatched."
+            exit 1
+          fi
+
+          current=$(awk '$1 == "appVersion:" { gsub(/"/, "", $2); print $2 }' charts/n8n/Chart.yaml)
+          if [[ ! "$current" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::charts/n8n/Chart.yaml appVersion is '$current', not a concrete version, so there is nothing to compare against."
+            exit 1
+          fi
+          echo "version=$current" >> "$GITHUB_OUTPUT"
+          echo "Current: $current"
+
+      - name: Resolve target version
+        id: target
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED: ${{ inputs.version }}
+          CURRENT: ${{ steps.current.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          if [[ -n "${REQUESTED:-}" ]]; then
+            target=$REQUESTED
+            source="the version input"
+          else
+            # The git tag refs/tags/stable is a different object and points at a
+            # prerelease. The stable release's target_commitish is the release
+            # branch, for example release/2.38.6.
+            target=$(gh api repos/n8n-io/n8n/releases/tags/stable --jq .target_commitish | sed 's|^release/||')
+            source="n8n's stable release"
+          fi
+
+          if [[ ! "$target" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::$source resolved to '$target', which is not a concrete version."
+            exit 1
+          fi
+
+          IFS=. read -r cur_major cur_minor cur_patch <<< "$CURRENT"
+          IFS=. read -r new_major new_minor new_patch <<< "$target"
+
+          if [[ "$new_major" != "$cur_major" ]]; then
+            echo "::error::$source is $target, which crosses a major from $CURRENT. An n8n major needs chart changes of its own, so this job will not do it."
+            exit 1
+          fi
+
+          if [[ "$target" == "$CURRENT" ]]; then
+            echo "Already on $CURRENT, nothing to do."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # 10# because a zero-padded field would otherwise be read as octal.
+          if (( 10#$new_minor < 10#$cur_minor ||
+                (10#$new_minor == 10#$cur_minor && 10#$new_patch < 10#$cur_patch) )); then
+            echo "::error::$source is $target, which is behind $CURRENT. This job only moves forwards; run scripts/bump-n8n-version.sh by hand for a rollback."
+            exit 1
+          fi
+
+          # release-please takes the chart increment from the commit type, so it
+          # follows the size of the n8n move.
+          if (( 10#$new_minor > 10#$cur_minor )); then
+            type=feat
+          else
+            type=fix
+          fi
+
+          {
+            echo "version=$target"
+            echo "type=$type"
+            echo "changed=true"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Bumping $CURRENT to $target as $type(chart)"
+
+      - name: Rewrite version pins
+        id: rewrite
+        if: steps.target.outputs.changed == 'true'
+        env:
+          VERSION: ${{ steps.target.outputs.version }}
+        run: |
+          set -euo pipefail
+          scripts/bump-n8n-version.sh "$VERSION"
+          git --no-pager diff --stat
+          # The PR body lists what actually moved rather than a prose list that
+          # would go stale the moment the set of pinned files changes. The
+          # checkout above is clean, so this and the commit below both see the
+          # script's rewrites and nothing else.
+          {
+            echo "files<<PINNED_FILES"
+            git diff --name-only
+            echo "PINNED_FILES"
+          } >> "$GITHUB_OUTPUT"
+
+      # Minted here rather than at the top of the job so every guard above can
+      # be exercised by a workflow_dispatch run without it, and so nothing holds
+      # a write token while running the steps that do not need one.
+      - name: Mint bot token
+        id: app-token
+        if: steps.target.outputs.changed == 'true'
+        # SHA pinned, not tag pinned: this is the one action in the repo handed
+        # a private key, same as ci.yml does for trivy-action.
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - name: Push bump branch
+        if: steps.target.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          VERSION: ${{ steps.target.outputs.version }}
+          TYPE: ${{ steps.target.outputs.type }}
+        run: |
+          set -euo pipefail
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${APP_SLUG}[bot]@users.noreply.github.com"
+          git commit --all --message "$TYPE(chart): bump n8n to $VERSION"
+          # A fixed branch, force pushed, so a stale open bump PR is updated
+          # rather than a second one opened alongside it. The branch belongs to
+          # this job: it is rebuilt from main every run, so anything pushed onto
+          # it by hand is discarded next Wednesday. Fix a red bump PR on its own
+          # branch, not on this one. No --force-with-lease for the same reason,
+          # a lease would stall the weekly bump on someone else's commit.
+          git push --force "https://x-access-token:$GH_TOKEN@github.com/$GITHUB_REPOSITORY" "HEAD:refs/heads/$BRANCH"
+
+      - name: Open or update PR
+        id: pr
+        if: steps.target.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          CURRENT: ${{ steps.current.outputs.version }}
+          VERSION: ${{ steps.target.outputs.version }}
+          TYPE: ${{ steps.target.outputs.type }}
+          FILES: ${{ steps.rewrite.outputs.files }}
+        run: |
+          set -euo pipefail
+
+          title="$TYPE(chart): bump n8n to $VERSION"
+
+          # This lands on main as the squash commit body, so it stays to the
+          # facts. Nothing in it is footer shaped, which would otherwise let the
+          # body override the increment the title asks for.
+          body=$(cat <<EOF
+          Moves the pinned n8n version from $CURRENT to $VERSION.
+
+          Updated:
+          $FILES
+
+          Release notes for $VERSION: https://github.com/n8n-io/n8n/releases/tag/n8n%40$VERSION
+          EOF
+          )
+
+          pr=$(gh pr list --head "$BRANCH" --base main --state open --json number --jq '.[0].number // empty')
+
+          if [[ -z "$pr" ]]; then
+            # The label has to be on the opened event: ci.yml's pull_request
+            # trigger declares no types, so labelling later re-triggers nothing.
+            # gh prints the new PR's URL, which the merge step takes as readily
+            # as a number and avoids listing again to find out what we just made.
+            pr=$(gh pr create --base main --head "$BRANCH" --title "$title" --body "$body" --label test-install)
+          else
+            gh pr edit "$pr" --title "$title" --body "$body" --add-label test-install
+          fi
+
+          if [[ -z "$pr" ]]; then
+            echo "::error::the PR was neither found nor created, so there is nothing to auto-merge."
+            exit 1
+          fi
+
+          echo "pr=$pr" >> "$GITHUB_OUTPUT"
+
+      - name: Enable auto-merge
+        if: steps.target.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR: ${{ steps.pr.outputs.pr }}
+        run: gh pr merge --auto --squash "$PR"

--- a/.github/workflows/bump-n8n-version.yml
+++ b/.github/workflows/bump-n8n-version.yml
@@ -225,7 +225,8 @@ jobs:
             # as a number and avoids listing again to find out what we just made.
             # The label is for humans reading the PR: gh applies labels after
             # the PR exists, so it is not in the `opened` event and does not by
-            # itself make install-test run. ci.yml's branch-name gate does that.
+            # itself make install-test run. ci.yml's gate job does that, off the
+            # branch name, so install-test runs from the opened event onwards.
             pr=$(gh pr create --base main --head "$BRANCH" --title "$title" --body "$body" --label test-install)
           else
             gh pr edit "$pr" --title "$title" --body "$body" --add-label test-install

--- a/.github/workflows/bump-n8n-version.yml
+++ b/.github/workflows/bump-n8n-version.yml
@@ -60,7 +60,7 @@ jobs:
           fi
 
           current=$(awk '$1 == "appVersion:" { gsub(/"/, "", $2); print $2 }' charts/n8n/Chart.yaml)
-          if [[ ! "$current" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          if [[ ! "$current" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
             echo "::error::charts/n8n/Chart.yaml appVersion is '$current', not a concrete version, so there is nothing to compare against."
             exit 1
           fi
@@ -87,7 +87,7 @@ jobs:
             source="n8n's stable release"
           fi
 
-          if [[ ! "$target" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          if [[ ! "$target" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
             echo "::error::$source resolved to '$target', which is not a concrete version."
             exit 1
           fi
@@ -95,6 +95,8 @@ jobs:
           IFS=. read -r cur_major cur_minor cur_patch <<< "$CURRENT"
           IFS=. read -r new_major new_minor new_patch <<< "$target"
 
+          # A string compare is exact here because the format check above
+          # rejects a zero-padded field, so 2 and 02 cannot both reach this.
           if [[ "$new_major" != "$cur_major" ]]; then
             echo "::error::$source is $target, which crosses a major from $CURRENT. An n8n major needs chart changes of its own, so this job will not do it."
             exit 1
@@ -106,7 +108,8 @@ jobs:
             exit 0
           fi
 
-          # 10# because a zero-padded field would otherwise be read as octal.
+          # 10# in case the format check is ever loosened: without it a
+          # zero-padded field would be read as octal, and 08 is not valid octal.
           if (( 10#$new_minor < 10#$cur_minor ||
                 (10#$new_minor == 10#$cur_minor && 10#$new_patch < 10#$cur_patch) )); then
             echo "::error::$source is $target, which is behind $CURRENT. This job only moves forwards; run scripts/bump-n8n-version.sh by hand for a rollback."
@@ -208,13 +211,21 @@ jobs:
           EOF
           )
 
-          pr=$(gh pr list --head "$BRANCH" --base main --state open --json number --jq '.[0].number // empty')
+          # --head matches on branch name alone, so a fork PR whose head branch
+          # is also called automated/bump-n8n would come back here and get
+          # retitled, relabelled and handed auto-merge. Only ever act on a PR
+          # from this repository. Qualifying --head as owner:branch does not
+          # work, it matches nothing at all, so filter on the PR instead.
+          pr=$(gh pr list --head "$BRANCH" --base main --state open \
+            --json number,isCrossRepository \
+            --jq 'map(select(.isCrossRepository == false)) | .[0].number // empty')
 
           if [[ -z "$pr" ]]; then
-            # The label has to be on the opened event: ci.yml's pull_request
-            # trigger declares no types, so labelling later re-triggers nothing.
             # gh prints the new PR's URL, which the merge step takes as readily
             # as a number and avoids listing again to find out what we just made.
+            # The label is for humans reading the PR: gh applies labels after
+            # the PR exists, so it is not in the `opened` event and does not by
+            # itself make install-test run. ci.yml's branch-name gate does that.
             pr=$(gh pr create --base main --head "$BRANCH" --title "$title" --body "$body" --label test-install)
           else
             gh pr edit "$pr" --title "$title" --body "$body" --add-label test-install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,53 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    # The first three are the defaults, respelled because naming any type
+    # replaces them. `labeled` is what makes adding test-install to an open PR
+    # actually run install-test, which previously did nothing until the next
+    # push. Every label change triggers a run, not just that one.
+    types: [opened, synchronize, reopened, labeled]
 
 permissions:
   contents: read
   security-events: write
 
 jobs:
+  # Where the install-test policy lives, in one place, so that the job's
+  # condition and the ci-ok check below cannot drift apart.
+  #
+  # It runs automatically for the version bump PR and for release-please's PRs,
+  # both of which auto-merge or release off the back of it, and on demand for
+  # anything else a maintainer labels. Only write access can add a label, and
+  # the branch names are only honoured on a branch in this repository, so a
+  # fork PR cannot name its way into a kind cluster.
+  gate:
+    runs-on: ubuntu-latest
+    outputs:
+      install-test: ${{ steps.decide.outputs.install-test }}
+    steps:
+      - name: Decide whether install-test runs
+        id: decide
+        env:
+          EVENT: ${{ github.event_name }}
+          LABELLED: ${{ contains(github.event.pull_request.labels.*.name, 'test-install') }}
+          SAME_REPO: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+
+          run=false
+          if [[ "$EVENT" == "pull_request" ]]; then
+            if [[ "$LABELLED" == "true" ]]; then
+              run=true
+            elif [[ "$SAME_REPO" == "true" ]] &&
+                 [[ "$HEAD_REF" == "automated/bump-n8n" || "$HEAD_REF" == release-please--* ]]; then
+              run=true
+            fi
+          fi
+
+          echo "install-test=$run" >> "$GITHUB_OUTPUT"
+          echo "install-test on this event: $run"
+
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -59,7 +100,8 @@ jobs:
 
   install-test:
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'test-install')
+    needs: gate
+    if: needs.gate.outputs.install-test == 'true'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -138,3 +180,46 @@ jobs:
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         with:
           sarif_file: trivy-results.sarif
+
+  # The single check to require on main. It exists for two reasons: a skipped
+  # job reports success to required status checks, so requiring install-test
+  # directly would let a bump PR merge untested if its condition ever stopped
+  # matching, and template-validation is a seven leg matrix that would
+  # otherwise need all seven names listing in the ruleset.
+  ci-ok:
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [gate, lint, template-validation, install-test, security-scan]
+    steps:
+      - name: Check the other jobs
+        env:
+          GATE: ${{ needs.gate.result }}
+          LINT: ${{ needs.lint.result }}
+          TEMPLATES: ${{ needs['template-validation'].result }}
+          SECURITY: ${{ needs['security-scan'].result }}
+          INSTALL: ${{ needs['install-test'].result }}
+          INSTALL_REQUIRED: ${{ needs.gate.outputs.install-test }}
+        run: |
+          set -euo pipefail
+
+          failed=0
+
+          for job in "gate:$GATE" "lint:$LINT" "template-validation:$TEMPLATES" "security-scan:$SECURITY"; do
+            if [[ "${job#*:}" != "success" ]]; then
+              echo "::error::${job%%:*} did not pass, it was ${job#*:}."
+              failed=1
+            fi
+          done
+
+          # install-test is allowed to be skipped, but only where the gate said
+          # it was not needed. Skipped on a PR that needed it is a failure.
+          if [[ "$INSTALL_REQUIRED" == "true" && "$INSTALL" != "success" ]]; then
+            echo "::error::install-test had to pass on this pull request, but it was $INSTALL."
+            failed=1
+          fi
+
+          if [[ "$failed" == "1" ]]; then
+            exit 1
+          fi
+
+          echo "All required jobs passed (install-test: $INSTALL, required: ${INSTALL_REQUIRED:-false})."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,11 @@ on:
     # The first three are the defaults, respelled because naming any type
     # replaces them. `labeled` is what makes adding test-install to an open PR
     # actually run install-test, which previously did nothing until the next
-    # push. Every label change triggers a run, not just that one.
-    types: [opened, synchronize, reopened, labeled]
+    # push. `unlabeled` is its counterpart: without it, taking the label off a
+    # PR whose install-test failed would leave the red ci-ok standing and block
+    # a PR that never needed the test. Any label change triggers a run, not
+    # just that one.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,12 +21,33 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
+    env:
+      # Mapped here because the `secrets` context is not available to a step's
+      # `if`, and the step below has to be able to tell whether the App exists.
+      RELEASE_APP_ID: ${{ secrets.RELEASE_APP_ID }}
     steps:
+      # A PR opened under GITHUB_TOKEN gets no pull_request event, so
+      # release-please's PRs get no CI at all: #182 sat for weeks with zero
+      # checks. Opening them as the App fixes that, and it is what lets
+      # ci.yml's gate run install-test on a release-please-- branch.
+      #
+      # Skipped while the App's secrets are absent, with release-please falling
+      # back to GITHUB_TOKEN, so releases keep working exactly as they do now
+      # and switch over on their own once the secrets land.
+      - name: Mint bot token
+        id: app-token
+        if: env.RELEASE_APP_ID != ''
+        # SHA pinned because this one is handed a private key.
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Run Release Please
         id: release
         uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,7 +169,9 @@ kubectl delete namespace n8n-test
 kind delete cluster --name n8n-test
 ```
 
-You can also let CI do this for you — add the `test-install` label to your PR and the install-test job will run automatically.
+You can also let CI do this for you: add the `test-install` label to your PR and the install-test job runs straight away, no push needed. A maintainer has to add it, and it is not required for your PR to merge.
+
+It runs on its own, without a label, for the version bump PR and for Release Please's PRs, and it has to pass before either can merge.
 
 ### Version Bumps
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,6 +175,14 @@ You can also let CI do this for you — add the `test-install` label to your PR 
 
 **Do not manually edit `Chart.yaml` version.** Release Please bumps it automatically based on commit messages.
 
+The n8n version is a separate thing from the chart version, and it is pinned in nine files: `appVersion` in `charts/n8n/Chart.yaml`, the four Compose and Caddy `.env` files, `kubernetes/n8n-deployment.yaml` and the `N8nVersion` default in the three ECS Fargate templates. Move them together, with the script:
+
+```bash
+scripts/bump-n8n-version.sh 2.38.6
+```
+
+The `bump-n8n-version` workflow runs the same script every Wednesday to follow n8n's `stable` release, so running it by hand is only for a rollback or for crossing an n8n major, neither of which the workflow will do on its own.
+
 ## Pull Requests
 
 - Add the `test-install` label to PRs that change chart templates to trigger a full install test on a kind cluster

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,21 +169,19 @@ kubectl delete namespace n8n-test
 kind delete cluster --name n8n-test
 ```
 
-You can also let CI do this for you: add the `test-install` label to your PR and the install-test job runs straight away, no push needed. A maintainer has to add it, and it is not required for your PR to merge.
-
-It runs on its own, without a label, for the version bump PR and for Release Please's PRs, and it has to pass before either can merge.
+Maintainers can label PRs with `test-install` to run the tests with CI.
 
 ### Version Bumps
 
 **Do not manually edit `Chart.yaml` version.** Release Please bumps it automatically based on commit messages.
 
-The n8n version is a separate thing from the chart version, and it is pinned in nine files: `appVersion` in `charts/n8n/Chart.yaml`, the four Compose and Caddy `.env` files, `kubernetes/n8n-deployment.yaml` and the `N8nVersion` default in the three ECS Fargate templates. Move them together, with the script:
+The n8n version is a separate thing to the chart version. It is pinned in multiple files across the various deployment artefacts.
+
+The `bump-n8n-version` workflow runs this script every Wednesday to follow n8n's `stable` release cadence. If you do need to bump the versions by hand, you can do so by running:
 
 ```bash
 scripts/bump-n8n-version.sh 2.38.6
 ```
-
-The `bump-n8n-version` workflow runs the same script every Wednesday to follow n8n's `stable` release, so running it by hand is only for a rollback or for crossing an n8n major, neither of which the workflow will do on its own.
 
 ## Pull Requests
 

--- a/scripts/bump-n8n-version.sh
+++ b/scripts/bump-n8n-version.sh
@@ -23,7 +23,7 @@ if [[ -z "$version" ]]; then
   exit 64
 fi
 
-if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+if [[ ! "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
   echo "error: '$version' is not a concrete n8n version such as 2.38.6" >&2
   exit 64
 fi

--- a/scripts/bump-n8n-version.sh
+++ b/scripts/bump-n8n-version.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+#
+# Rewrite every n8n version pin in this repo to the version given.
+#
+#   scripts/bump-n8n-version.sh 2.38.6
+#
+# Deliberately mechanical: it validates the version format, rewrites nine
+# lines and does nothing else. It never resolves `stable`, compares versions
+# or touches git, so it is safe to run by hand, including to roll back to an
+# older version. Those decisions belong to the job that calls it,
+# .github/workflows/bump-n8n-version.yml.
+#
+# Every pin has to match exactly one line, and all nine are checked before any
+# are written, so a file whose shape has changed fails the run instead of
+# being quietly skipped or leaving the tree half rewritten.
+
+set -euo pipefail
+
+version=${1:-}
+
+if [[ -z "$version" ]]; then
+  echo "usage: ${0##*/} <version>, for example ${0##*/} 2.38.6" >&2
+  exit 64
+fi
+
+if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "error: '$version' is not a concrete n8n version such as 2.38.6" >&2
+  exit 64
+fi
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+# Each pin is a file plus an awk program that rewrites its version line and
+# counts what it rewrote in `hits`, exiting non-zero unless it saw exactly one.
+files=()
+programs=()
+
+pin() {
+  files+=("$1")
+  programs+=("$2")
+}
+
+# The chart's appVersion. image.tag and taskRunners.image.tag both fall back to
+# it through the n8n.imageTag helpers, so this is the chart's only pin.
+pin charts/n8n/Chart.yaml '
+  /^appVersion:/ { print "appVersion: \"" version "\""; hits++; next }
+  { print }
+  END { exit(hits == 1 ? 0 : 1) }
+'
+
+# Compose and Caddy. Their n8n and runners images both interpolate
+# ${N8N_VERSION}, so one line per stack moves both.
+for env_file in \
+  docker-compose/withPostgres/.env \
+  docker-compose/withPostgresAndWorker/.env \
+  docker-compose/subfolderWithSSL/.env \
+  docker-caddy/.env; do
+  pin "$env_file" '
+    /^N8N_VERSION=/ { print "N8N_VERSION=" version; hits++; next }
+    { print }
+    END { exit(hits == 1 ? 0 : 1) }
+  '
+done
+
+# The raw manifest. Matching on the colon leaves the busybox init container
+# alone and refuses an untagged n8nio/n8n line rather than pinning it blind.
+pin kubernetes/n8n-deployment.yaml '
+  /^[[:space:]]*image: n8nio\/n8n:/ {
+    sub(/image: n8nio\/n8n:.*/, "image: n8nio/n8n:" version)
+    hits++
+  }
+  { print }
+  END { exit(hits == 1 ? 0 : 1) }
+'
+
+# The ECS Fargate templates carry the version once each, as the default of
+# their N8nVersion parameter, which every n8nio/n8n and n8nio/runners
+# reference !Subs. Only the Default inside that parameter block is touched.
+for template in \
+  aws-cloudformation/ecs-fargate/n8n-w-multimain-queuemode.yaml \
+  aws-cloudformation/ecs-fargate/n8n-w-multimain-queuemode-webhooks.yaml \
+  aws-cloudformation/ecs-fargate/n8n-w-multimain-queuemode-webhooks-ha.yaml; do
+  pin "$template" '
+    /^  N8nVersion:/ { in_block = 1 }
+    in_block && /^  [A-Za-z]/ && !/^  N8nVersion:/ { in_block = 0 }
+    in_block && /^    Default:/ {
+      sub(/Default:.*/, "Default: \"" version "\"")
+      hits++
+    }
+    { print }
+    END { exit(hits == 1 ? 0 : 1) }
+  '
+done
+
+# Check pass. Nothing is written until every pin has been found exactly once.
+for i in "${!files[@]}"; do
+  file=${files[$i]}
+
+  if [[ ! -f "$file" ]]; then
+    echo "error: $file is missing" >&2
+    exit 1
+  fi
+
+  if ! awk -v version="$version" "${programs[$i]}" "$file" >/dev/null; then
+    echo "error: $file has no single line matching the expected pin, its shape has changed" >&2
+    exit 1
+  fi
+done
+
+# Write pass. Output goes through a temp file because `sed -i` takes different
+# arguments on GNU and BSD, and this runs both on an Actions runner and on a
+# maintainer's Mac. Copying the temp file back keeps the original's mode.
+echo "Pinning n8n $version in:"
+
+for i in "${!files[@]}"; do
+  file=${files[$i]}
+  tmp=$(mktemp)
+  awk -v version="$version" "${programs[$i]}" "$file" >"$tmp"
+  cat "$tmp" >"$file"
+  rm -f "$tmp"
+  echo "  $file"
+done


### PR DESCRIPTION
Throwaway. Same commits as #195, on a branch named `release-please--smoke-test` so that `ci.yml`'s gate treats it as a release PR and runs `install-test` for real.

Checking two things: that the branch-name condition fires, and whether `install-test` still passes at all, given it has not run in 200 runs and installs Postgres and Redis from Bitnami's index.

Will be closed and the branch deleted as soon as the run finishes. Do not review.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n-hosting/pull/196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

